### PR TITLE
checking for fileobj in save method

### DIFF
--- a/svgwrite/drawing.py
+++ b/svgwrite/drawing.py
@@ -113,7 +113,10 @@ class Drawing(SVG, ElementFactory):
 
     def save(self, pretty=False):
         """ Write the XML string to **filename**. """
-        fileobj = io.open(self.filename, mode='w', encoding='utf-8')
+        if isinstance(self.filename, str):
+            fileobj = io.open(self.filename, mode='w', encoding='utf-8')
+        else:
+            fileobj = self.filename
         self.write(fileobj, pretty=pretty)
         fileobj.close()
 


### PR DESCRIPTION
If Drawing.filename is a string, open a file using Drawing.filename as the filename. Else, write to the object directly. This allows SVGs to be written in limited environments, like on google cloud platform or AWS, where access to the filesystem is limited, but it is possible to create FileObjects in memory or other clients. For example, in google appengine:

```
import cloudstorage
file = cloudstorage.open('mysvg.svg', 'w')
drawing = Drawing(file)
drawing.save()
```