### PR TITLE
Enable _repr_svg_ for IPython/Jupyter

### DIFF
--- a/svgwrite/base.py
+++ b/svgwrite/base.py
@@ -189,6 +189,14 @@ class BaseElement(object):
         xml_utf8_str = etree.tostring(xml, encoding='utf-8')
         return xml_utf8_str.decode('utf-8')
         # just Python 3: return etree.tostring(xml, encoding='unicode')
+    
+    def _repr_svg_(self):
+        """ Show SVG in IPython, Jupyter Notebook, and Jupyter Lab
+
+        :return: unicode XML string of this object and all its subelements
+
+        """
+        return self.tostring()
 
     def get_xml(self):
         """ Get the XML representation as `ElementTree` object.

--- a/svgwrite/drawing.py
+++ b/svgwrite/drawing.py
@@ -125,5 +125,13 @@ class Drawing(SVG, ElementFactory):
         """
         self.filename = filename
         self.save(pretty=pretty)
+    
+    def _repr_svg_(self):
+        """ Show SVG in IPython, Jupyter Notebook, and Jupyter Lab
+
+        :return: unicode XML string of this object and all its subelements
+
+        """
+        return self.tostring()
 
 


### PR DESCRIPTION
This commit adds a display method hook for IPython, Jupyter Notebook, and Jupyter Lab

base.py and drawing.py each received:
```
def _repr_svg_(self):
    return self.tostring()
```

Ref:
https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html
https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.formatters.html