### PR TITLE
Add viewport units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 svgwrite.egg-info/*
 doc/_build/*
 issues/2017-01-28 nads_debugging
+.tox/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyparsing>=2.0.1
+pytest>=4.4
+tox>=3.8

--- a/svgwrite/data/pattern.py
+++ b/svgwrite/data/pattern.py
@@ -8,8 +8,8 @@
 
 import re
 
-#coordinate ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%")?
-coordinate = re.compile(r"(^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)(cm|em|ex|in|mm|pc|pt|px|%)?$")
+#coordinate ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%" | "vw" | "vh")?
+coordinate = re.compile(r"(^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)(cm|em|ex|in|mm|pc|pt|px|%|vw|vh)?$")
 
 #length ::= number ("em" | "ex" | "px" | "in" | "cm" | "mm" | "pt" | "pc" | "%")?
 length = coordinate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,8 @@ class TestRectTopLeftCorner(unittest.TestCase):
         self.assertRaises(ValueError, rect_top_left_corner, insert=(1, 1), size=(1, 1), pos='mitte-center')
 
 class TestSplitCoordinate(unittest.TestCase):
+    units = ("", "em", "ex", "px", "in", "cm", "mm", "pt", "pc", "%", "vw", "vh")
+
     def test_int_coordinates(self):
         res = split_coordinate(10)
         self.assertEqual(res, (10, None))
@@ -99,10 +101,10 @@ class TestSplitCoordinate(unittest.TestCase):
         self.assertEqual(res, (7.9, None))
 
     def test_valid_str_coordinates(self):
-        res = split_coordinate('10cm')
-        self.assertEqual(res, (10, 'cm'))
-        res = split_coordinate('10.7in')
-        self.assertEqual(res, (10.7, 'in'))
+        for unit in self.units:
+            for number in (10, 10.7):
+                res = split_coordinate(str(number) + unit)
+                self.assertEqual(res, (number, unit or None))
 
     def test_invalid_str_coordinates(self):
         self.assertRaises(ValueError, split_coordinate, '100km')


### PR DESCRIPTION
Previously, coordinate-splitting did not allow viewport units `"vh"` and `"vw"`. Now it does. Includes test.

Resolves #42 

Also: added `.tox/` to gitignore, and added testing tools to requirements.txt.