### PR TITLE
Fix SyntaxWarning due to unescaped escape sequences

### DIFF
--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -33,8 +33,8 @@ class TestLinearGradient(unittest.TestCase):
 
     def test_get_paint_server(self):
         lg = LinearGradient()
-        self.assertTrue(re.match("^url\(#id\d+\) none$", lg.get_paint_server()))
-        self.assertTrue(re.match("^url\(#id\d+\) red$", lg.get_paint_server(default='red')))
+        self.assertTrue(re.match(r"^url\(#id\d+\) none$", lg.get_paint_server()))
+        self.assertTrue(re.match(r"^url\(#id\d+\) red$", lg.get_paint_server(default='red')))
 
     def test_add_stop_color(self):
         lg = LinearGradient()
@@ -65,8 +65,8 @@ class TestRadialGradient(unittest.TestCase):
 
     def test_get_paint_server(self):
         rg = RadialGradient()
-        self.assertTrue(re.match("^url\(#id\d+\) none$", rg.get_paint_server()))
-        self.assertTrue(re.match("^url\(#id\d+\) red$", rg.get_paint_server(default='red')))
+        self.assertTrue(re.match(r"^url\(#id\d+\) none$", rg.get_paint_server()))
+        self.assertTrue(re.match(r"^url\(#id\d+\) red$", rg.get_paint_server(default='red')))
 
     def test_add_stop_color(self):
         rg = RadialGradient()

--- a/tests/test_marker_class.py
+++ b/tests/test_marker_class.py
@@ -26,7 +26,7 @@ class TestMarker(unittest.TestCase):
         marker = Marker(debug=True, profile='full')
         marker.add(Group())
         self.assertTrue(
-            re.match('^<marker id="id\d+"><g /></marker>$',
+            re.match(r'^<marker id="id\d+"><g /></marker>$',
                      marker.tostring()), "getting an autoid for class Marker failed.")
 
     def test_insert(self):

--- a/tests/test_xlink.py
+++ b/tests/test_xlink.py
@@ -42,7 +42,7 @@ class TestIXLink(unittest.TestCase):
         g = Group()
         m = Mock()
         m.set_href(g)
-        self.assertTrue(re.match('^<use xlink:href="#id\d+" />$', m.tostring()))
+        self.assertTrue(re.match(r'^<use xlink:href="#id\d+" />$', m.tostring()))
 
     def test_set_xlink_show(self):
         m = Mock()


### PR DESCRIPTION
From Python 3.8 with https://bugs.python.org/issue32912 `SyntaxWarning` is raised for unescaped sequences. This can be fixed by using raw string literals. 

Sample warnings : 

```
python tests/test_gradients.py
tests/test_gradients.py:36: SyntaxWarning: invalid escape sequence \(
  self.assertTrue(re.match("^url\(#id\d+\) none$", lg.get_paint_server()))
tests/test_gradients.py:37: SyntaxWarning: invalid escape sequence \(
  self.assertTrue(re.match("^url\(#id\d+\) red$", lg.get_paint_server(default='red')))
tests/test_gradients.py:68: SyntaxWarning: invalid escape sequence \(
  self.assertTrue(re.match("^url\(#id\d+\) none$", rg.get_paint_server()))
tests/test_gradients.py:69: SyntaxWarning: invalid escape sequence \(
  self.assertTrue(re.match("^url\(#id\d+\) red$", rg.get_paint_server(default='red')))
```