### PR TITLE
Manually sort XML attributes

### DIFF
--- a/svgwrite/base.py
+++ b/svgwrite/base.py
@@ -207,7 +207,7 @@ class BaseElement(object):
         xml = etree.Element(self.elementname)
         if self.debug:
             self.validator.check_all_svg_attribute_values(self.elementname, self.attribs)
-        for attribute, value in self.attribs.items():
+        for attribute, value in sorted(self.attribs.items()):
             # filter 'None' values
             if value is not None:
                 value = self.value_to_string(value)


### PR DESCRIPTION
Since Python 3.8 attributes are no longer automatically sorted,
see https://bugs.python.org/issue34160

----
This was originally reported in #51 but I wasn't able to find the fix.

The `test_pretty_xml` test case is still failing on 3.8 even with this. Looks like running `parseString` and `toprettyxml` now moves the XML Namespace attributes. I don't know if this is intentional or if it can be considered bug in Python. I'd personally probably just move the xmlns attributes in the test to match the expected result but I'm not an XML/SVG expert.

Failed test with Python 3.8:

```
======================================================================
FAIL: test_pretty_print (test_pretty_xml.TestPrettyXML)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/svgwrite-1.3.0/tests/test_pretty_xml.py", line 20, in test_pretty_print
    self.assertEqual(e, r)
AssertionError: '<svg baseProfile="full" height="100%" version=[164 chars]nk">' != '<svg xmlns="http://www.w3.org/2000/svg" xmlns:[164 chars]0%">'
- <svg baseProfile="full" height="100%" version="1.1" viewBox="0,0,10000,10000" width="100%" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="full" height="100%" version="1.1" viewBox="0,0,10000,10000" width="100%">
```