### PR TITLE
docs: explain why factory methods are members of Drawing

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1,15 +1,14 @@
 Overview
 ========
 
-As the name `svgwrite` implies, `svgwrite` creates new SVG drawings, it does not read existing drawings and also does
-not import existing drawings, but you can always include other SVG drawings by the <image> entity.
+As the name `svgwrite` implies, `svgwrite` creates new SVG drawings, it does not read/import existing drawings, but you can always include other SVG drawings by the `<image>` entity.
 
 `svgwrite` has a debugging feature, activated by :code:`svgwrite.Drawing(debug=True)`. This feature is meant to find
-SVG errors produced by your code while developing, this validation algorithm is not optimized and therefor very slow for
-big SVG files, that will not change in the future. And because it is slow DON'T use it in production code!
+SVG errors produced by your code while developing. This validation algorithm is not optimized and therefore very slow for
+big SVG files. That will not change in the future. And because it is slow DON'T use it in production code!
 
-If `svgwrite` without debugging is still to slow, you have to use the lxml package without `svgwrite` as wrapper, that
-is the ugly truth, `svgwrite` is just a wrapper around xml.etree.ElementTree. If you learn the ElementTree API and the
+If `svgwrite` without debugging is still too slow, you have to use the `lxml` package without `svgwrite` as wrapper. That
+is the ugly truth since `svgwrite` is just a wrapper around `xml.etree.ElementTree`. If you learn the ElementTree API and the
 SVG elements and attributes, you do not need `svgwrite`.
 
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -19,6 +19,7 @@ SVG Elements
 .. IMPORTANT::
 
    Use the **factory-methods** of the class **Drawing** to create new objects.
+   (This is necessary to support validation for different SVG versions.)
    All **factory-methods** have the original SVG Elementname (e.g. Drawing.a(...),
    Drawing.g(...), Drawing.symbol(...), Drawing.line(...))
 


### PR DESCRIPTION
The question of why factory methods need to be members of the `Drawing` class is better addressed in the docs, since I had the same question as #63 and I suspect many programmers will have the same. The answer is taken from @mozman's reply in closing that issue.