### PR TITLE
proposal to add method  BaseElement.add_to() which returns self.

### DIFF
--- a/doc/classes/base.rst
+++ b/doc/classes/base.rst
@@ -21,6 +21,8 @@ Methods
 
 .. automethod:: svgwrite.base.BaseElement.add
 
+.. automethod:: svgwrite.base.BaseElement.add_to
+
 .. automethod:: svgwrite.base.BaseElement.tostring
 
 .. automethod:: svgwrite.base.BaseElement.get_xml

--- a/svgwrite/base.py
+++ b/svgwrite/base.py
@@ -178,6 +178,16 @@ class BaseElement(object):
         self.elements.append(element)
         return element
 
+    def add_to(self, parent):
+        """ Add this SVG element to a parent element. Alternatively use the .add(element) method to add a child to this element.
+
+        :param parent: the parent SVG element to which this element will be appended
+        :returns: this element 
+
+        """
+        parent.add(self)
+        return self
+
     def tostring(self):
         """ Get the XML representation as unicode `string`.
 


### PR DESCRIPTION
This proposal would allow elements to be added to a parent element in a chained call after the constructor:
```python
import svgwrite
dwg = svgwrite.Drawing()
dwg.g(id="eg").add_to(dwg).rotate(90)
``` 
The current way is to use a nested call:
```python
import svgwrite
dwg = svgwrite.Drawing()
dwg.add(dwg.g(id="eg")).rotate(90)
```

My motivation for improved chaining support is that I find it easier to use the helper functions such as .fill() and .rotate() rather than passing in these properties as parameters to the element constructor. The helper functions have better hinting in the interpreter.

This is my first attempt to contribute code to an open source project, not sure if a pull request is the correct etiquette to suggest this type of change? I have attempted to update the documentation, but I could not work out how I should add the required tests.

If this is received favourably I would also like to request that other functions such as the methods in the `Transform` class also be changed to `return self`. May I please have your opinion on this? I am not sure if that would break anything as I have not tried it yet.

If only this pull request is accepted then the following code will not work
```python
import svgwrite
dwg = svgwrite.Drawing()
dwg.g(id="eg").add_to(dwg).rotate(90).rotate(90)
# error: NoneType has no attribute 'rotate'
``` 
this is because the rotate() function returns None.

Also if you want to store a reference to the element: Whatever way the element is constructed you still lose the reference after calling `.rotate()`
```python
import svgwrite
dwg = svgwrite.Drawing()
elementa = dwg.add(dwg.g(id="eg")).rotate(90)
elementb = dwg.g(id="eg").add_to(dwg).rotate(90)

print(elementa.tostring())  # error: NoneType has not attribute 'tostring'
print(elementb.tostring()) # error: NoneType has not attribute 'tostring'
```
