### PR TITLE
Use pathlib.Path for dir/file manipulation

### DIFF
--- a/examples/LSystem.py
+++ b/examples/LSystem.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import math
 import svgwrite

--- a/examples/basic_shapes.py
+++ b/examples/basic_shapes.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 from svgwrite import cm, mm   

--- a/examples/checkerboard.py
+++ b/examples/checkerboard.py
@@ -7,12 +7,12 @@
 # License: MIT License
 
 import sys
-import os
+from pathlib import Path
 
 try:
     import svgwrite
 except ImportError:
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 if svgwrite.version < (1,0,1):

--- a/examples/fePointLight.py
+++ b/examples/fePointLight.py
@@ -5,8 +5,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 dwg = svgwrite.Drawing("fePointLight.svg")

--- a/examples/hyperlink.py
+++ b/examples/hyperlink.py
@@ -9,8 +9,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/koch_snowflake.py
+++ b/examples/koch_snowflake.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import math
 import svgwrite

--- a/examples/linearGradient.py
+++ b/examples/linearGradient.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/ltattrie/xkcd_colour_data_svgwrite_3.py
+++ b/examples/ltattrie/xkcd_colour_data_svgwrite_3.py
@@ -6,12 +6,12 @@
 # License: LGPL
 # Python version 2.7
 import sys
-import os
 import colorsys
 import svgwrite
+from pathlib import Path
 
 PROGNAME = sys.argv[0].rstrip('.py')
-RGB_TXT = 'rgb.txt'
+RGB_TXT = Path('rgb.txt')
 
 # To Do
 #   Automate the file name and title and axis swatch_y
@@ -62,7 +62,7 @@ def create_svg(name):
     swatch_w = 10 # swatch width
     swatch_h = 10 # swatch height
 
-    if not os.path.exists(RGB_TXT):
+    if not RGB_TXT.exists():
       print("Error.  The data file is not readable. File name is: %s" % RGB_TXT)
       sys.exit(1)
 
@@ -79,7 +79,7 @@ def create_svg(name):
     # You can also use other family names like "Times", "Baskerville", "Verdena", and "Symbol." I got those names from the CSS specification and some experimenting, but I'm looking for more.
     # 'font-weight' Value:  	normal | bold + others.
 
-    for line_count, line in enumerate(open(RGB_TXT)):
+    for line_count, line in enumerate(RGB_TXT.read_text().splitlines()):
         colour_item = line.split('\t')
         # strip the trailing newline \n char then split by the tab chars
         colour_item = line.strip().split('\t')

--- a/examples/mandelbrot.py
+++ b/examples/mandelbrot.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 from svgwrite import rgb

--- a/examples/marker.py
+++ b/examples/marker.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/pattern.py
+++ b/examples/pattern.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/radialGradient.py
+++ b/examples/radialGradient.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/simple_text.py
+++ b/examples/simple_text.py
@@ -9,8 +9,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/solidcolor.py
+++ b/examples/solidcolor.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 

--- a/examples/use.py
+++ b/examples/use.py
@@ -10,8 +10,9 @@ try:
     import svgwrite
 except ImportError:
     # if svgwrite is not 'installed' append parent dir of __file__ to sys.path
-    import sys, os
-    sys.path.insert(0, os.path.abspath(os.path.split(os.path.abspath(__file__))[0]+'/..'))
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import svgwrite
 from svgwrite import cm, mm, rgb, deg

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,22 @@
 #!/usr/bin/env python3
 # License: MIT License
 # Copyright (C) 2010-2020  Manfred Moitzi
-import os
+from pathlib import Path
 from setuptools import setup
 
 AUTHOR_NAME = 'Manfred Moitzi'
 AUTHOR_EMAIL = 'me@mozman.at'
 
+ROOT = Path(__file__).resolve().parent
 
 def get_version():
     v = {}
     # do not import svgwrite, because required packages may not installed yet
-    for line in open('./svgwrite/version.py').readlines():
+    for line in (ROOT / "svgwrite" / "version.py").read_text().splitlines():
         if line.strip().startswith('__version__'):
             exec(line, v)
             return v['__version__']
     raise IOError('__version__ string not found')
-
-
-def read(fname):
-    try:
-        return open(os.path.join(os.path.dirname(__file__), fname)).read()
-    except IOError:
-        return "File '%s' not found.\n" % fname
 
 
 setup(name='svgwrite',
@@ -35,7 +29,8 @@ setup(name='svgwrite',
       python_requires='>=3.6',
       packages=['svgwrite', 'svgwrite/data', 'svgwrite/extensions'],
       provides=['svgwrite'],
-      long_description=read('README.rst') + read('NEWS.rst'),
+      long_description=((ROOT / 'README.rst').read_text() +
+                        (ROOT / 'NEWS.rst').read_text()),
       platforms="OS Independent",
       license="MIT License",
       classifiers=[

--- a/svgwrite/utils.py
+++ b/svgwrite/utils.py
@@ -24,8 +24,8 @@
 .. autofunction:: pretty_xml
 
 """
-import os
 import base64
+from pathlib import Path
 from svgwrite.data import pattern
 
 
@@ -249,8 +249,7 @@ FONT_MIMETYPES = {
 
 
 def font_mimetype(name):
-    _, ext = os.path.splitext(name.lower())
-    return FONT_MIMETYPES[ext[1:]]
+    return FONT_MIMETYPES[Path(name.lower()).suffix[1:]]
 
 
 def base64_data(data, mimetype):

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -5,9 +5,9 @@
 # Created: 11.09.2010
 # Copyright (C) 2010, Manfred Moitzi
 # License: MIT License
-import os
 import unittest
 from io import StringIO
+from pathlib import Path
 
 from svgwrite.drawing import Drawing
 from svgwrite.container import Group
@@ -36,22 +36,22 @@ class TestDrawingFullProfile(unittest.TestCase):
                                  'xmlns:xlink="http://www.w3.org/1999/xlink"><defs /></svg>')
 
     def test_save(self):
-        fn = 'test_drawing.svg'
-        if os.path.exists(fn):
-            os.remove(fn)
+        fn = Path('test_drawing.svg')
+        if fn.exists():
+            fn.unlink()
         dwg = Drawing(fn)
         dwg.save()
-        self.assertTrue(os.path.exists(fn))
-        os.remove(fn)
+        self.assertTrue(fn.exists())
+        fn.unlink()
 
     def test_save_as(self):
-        fn = 'test_drawing.svg'
-        if os.path.exists(fn):
-            os.remove(fn)
+        fn = Path('test_drawing.svg')
+        if fn.exists():
+            fn.unlink()
         dwg = Drawing()
-        dwg.saveas(fn)
-        self.assertTrue(os.path.exists(fn))
-        os.remove(fn)
+        dwg.saveas(str(fn))
+        self.assertTrue(fn.exists())
+        fn.unlink()
 
     def test_non_us_ascii_chars(self):
         dwg = Drawing()


### PR DESCRIPTION
`svgwrite` works with files using `io.open` which supports `pathlib.Path` objects as well, so this could be mentioned in the documentation. What do you think?