### PR TITLE
Remove redundant Python2 float/int conversions

### DIFF
--- a/examples/LSystem.py
+++ b/examples/LSystem.py
@@ -65,7 +65,7 @@ def LSystem(name, formula=LevyCurve):
     numAngle = formula['numAngle']
     length = formula['length']
     fractal = _LSystem(formula)
-    na = 2.0 * math.pi / numAngle
+    na = 2 * math.pi / numAngle
     sn = []
     cs = []
     for i in range(numAngle):

--- a/examples/koch_snowflake.py
+++ b/examples/koch_snowflake.py
@@ -23,9 +23,9 @@ def koch_snowflake(name):
     # http://code.activestate.com/recipes/577156-koch-snowflake-and-sierpinski-triangle-combination/
 
     def tf (x0, y0, x1, y1, x2, y2):
-        a = math.sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2)
-        b = math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
-        c = math.sqrt((x0 - x2) ** 2 + (y0 - y2) ** 2)
+        a = math.hypot(x1 - x0, y1 - y0)
+        b = math.hypot(x2 - x1, y2 - y1)
+        c = math.hypot(x0 - x2, y0 - y2)
 
         if (a < stop_val) or (b < stop_val) or (c < stop_val):
             return
@@ -45,7 +45,7 @@ def koch_snowflake(name):
         tf(x5, y5, x4, y4, x2, y2)
 
     def sf (ax, ay, bx, by):
-        f = math.sqrt((bx - ax) ** 2 + (by - ay) ** 2)
+        f = math.hypot(bx - ax, by - ay)
 
         if f < 1.:
             return

--- a/examples/ltattrie/color_triangles_function.py
+++ b/examples/ltattrie/color_triangles_function.py
@@ -22,7 +22,7 @@ def create_svg(name):
     FONT_SIZE = 20
     COMPLETE_SIZE = 800   # size of the whole set of triangles.
     TRIANGLES_PER_SIDE = 50     # How many triangles there will be per side. integer.
-    TRIHEIGHT = math.sqrt(3)/2.0
+    TRIHEIGHT = math.sqrt(3) / 2
 
     title1 = name + ': Example of creating your own colors.'
     start = ((WIDTH - COMPLETE_SIZE)/2, (HEIGHT - COMPLETE_SIZE)/2)  # center triangle
@@ -34,7 +34,7 @@ def create_svg(name):
 
     def draw_triangle(insert, size, fill, rotate=None):
         x, y = insert
-        points = [insert, (x + size, y), ((x + size / 2.0), (y + size * TRIHEIGHT))]
+        points = [insert, (x + size, y), ((x + size / 2), (y + size * TRIHEIGHT))]
         triangle = dwg.add(dwg.polygon(points, fill=fill, stroke='none'))
         if rotate:
             triangle.rotate(rotate, center=insert)
@@ -70,7 +70,7 @@ def create_svg(name):
         ratio_row = nfrange(0.0, 1.0, num_tri_in_row) if num_tri_in_row > 1 else [0.5]
 
         for j in range(i):
-            x = start[0] + (j + ((TRIANGLES_PER_SIDE - i) / 2.0)) * tri_size
+            x = start[0] + (j + ((TRIANGLES_PER_SIDE - i) / 2)) * tri_size
             y = start[1] + (TRIANGLES_PER_SIDE - i) * tri_height
             # Calculate color
             new_color = [int(start_color[k] * (1 - ratio_row[num_tri_drawn_in_row ]) +

--- a/examples/ltattrie/tenticles.py
+++ b/examples/ltattrie/tenticles.py
@@ -27,9 +27,9 @@ def gen_colour(start_p, end_p, n_p):
     n = n_p
     # yielding a c_end separately gives the exact c_end thus not something that is 99.99% c_end which is slightly off colour.
     for i in range(n):
-        ccolour = (int(c_start[0] + (float(i) / float(n))*(c_end[0] - c_start[0])),
-                   int(c_start[1] + (float(i) / float(n))*(c_end[1] - c_start[1])),
-                   int(c_start[2] + (float(i) / float(n))*(c_end[2] - c_start[2])))
+        ccolour = (int(c_start[0] + (i / n) * (c_end[0] - c_start[0])),
+                   int(c_start[1] + (i / n) * (c_end[1] - c_start[1])),
+                   int(c_start[2] + (i / n) * (c_end[2] - c_start[2])))
         yield ccolour
     yield c_end
 
@@ -92,7 +92,7 @@ class tendrile:
     def angle_set(self, p_val):
         # limit the angle to range -2*math.pi to 2*math.pi  which is +- full circle.
         # Use math.fmod because % returns with the sign of the second number.
-        self.angle = math.fmod(p_val, (2 * math.pi))
+        self.angle = math.fmod(p_val, 2 * math.pi)
 
     def create(self):
         global file_log
@@ -140,7 +140,7 @@ class tendrile:
                     # The use of the original colour, usually darker green, to start the new tendrile gives a slight look
                     # of shadow on the the start of the new tendrile. It also gives a clear visual
                     # separation between the existing tendrile and the new tendrile.
-                    tend = tendrile(x_temp, y_temp, self.r, self.angle, (self.step * 1.2), (-1.0 * self.v),
+                    tend = tendrile(x_temp, y_temp, self.r, self.angle, (self.step * 1.2), (-1 * self.v),
                             self.curl, (self.n - i - 1), self.scolour, self.ecolour, False)
                     # create the tendrile as svg elements
                     tend.create()
@@ -187,7 +187,7 @@ class tendrile:
                     #self.angle += self.v
                     self.angle_set(self.angle + self.v)  # limit value of angle
                     #self.angle   = max(min(self.angle, angle_max), angle_min)  # limit value of angle
-            self.r = (1 - float(i) / self.n) * self.width  # radius size gradually decreases.
+            self.r = (1 - i / self.n) * self.width  # radius size gradually decreases.
             ##
             new_colour = next(self.lin_colour)
             stroke_colour = 'rgb(%s,%s,%s)' % new_colour
@@ -237,7 +237,7 @@ def create_svg(name):
     #num_arms = 9
     #step = 0.05
     #step = 0.02
-    step = 4.0 / n
+    step = 4 / n
     #curl = 1.0
     #c_width= d_width/12.0
     #c_width= d_width/50.0
@@ -283,7 +283,7 @@ def create_svg(name):
         # set start of arm x y
         x = d_height / 2
         y = d_width / 2
-        angle = random.uniform((-1.0 * math.pi), math.pi)  # random angle in radians. 2*pi radians = 360 degrees
+        angle = random.uniform(-math.pi, math.pi)  # random angle in radians. 2*pi radians = 360 degrees
         v = 0.0
         # variety to the size of the starting circle
         c_width = random.uniform((d_width * .015), (d_width * .025))

--- a/examples/ltattrie/tiling_part_1.py
+++ b/examples/ltattrie/tiling_part_1.py
@@ -90,7 +90,7 @@ def create_svg(name):
             # rotate every second square
 
             if j % 2:
-                sq_created.rotate(180, center=(x + square_size / 2.0, y + square_size / 2.0))
+                sq_created.rotate(180, center=(x + square_size / 2, y + square_size / 2))
             dwg.add(sq_created)
     y += square_size
 
@@ -108,7 +108,7 @@ def create_svg(name):
             # rotate every second row
 
             if i % 2 == 1:
-                sq_created.rotate(180, center=(x + square_size / 2.0, y + square_size / 2.0))
+                sq_created.rotate(180, center=(x + square_size / 2, y + square_size / 2))
             dwg.add(sq_created)
     y += square_size
 
@@ -126,7 +126,7 @@ def create_svg(name):
             # rotate every second square
 
             if i % 2 != j % 2:
-                sq_created.rotate(180, center=(x + square_size / 2.0, y + square_size / 2.0))
+                sq_created.rotate(180, center=(x + square_size / 2, y + square_size / 2))
             dwg.add(sq_created)
     y += square_size
 
@@ -148,11 +148,11 @@ def create_svg(name):
                 # odd row
 
                 if j % 2:
-                    sq_created.rotate(-90, center=(x + square_size / 2.0, y + square_size / 2.0))
+                    sq_created.rotate(-90, center=(x + square_size / 2, y + square_size / 2))
                 else:
-                    sq_created.rotate(180, center=(x + square_size / 2.0, y + square_size / 2.0))
+                    sq_created.rotate(180, center=(x + square_size / 2, y + square_size / 2))
             elif j % 2:
-                sq_created.rotate(90, center=(x + square_size / 2.0, y + square_size / 2.0))
+                sq_created.rotate(90, center=(x + square_size / 2, y + square_size / 2))
             dwg.add(sq_created)
     y += square_size
 
@@ -174,11 +174,11 @@ def create_svg(name):
                 # even row
 
                 if j % 2:
-                    sq_created.rotate(180, center=(x + square_size / 2.0, y + square_size / 2.0))
+                    sq_created.rotate(180, center=(x + square_size / 2, y + square_size / 2))
                 else:
-                    sq_created.rotate(-90, center=(x + square_size / 2.0, y + square_size / 2.0))
+                    sq_created.rotate(-90, center=(x + square_size / 2, y + square_size / 2))
             elif j % 2:
-                sq_created.rotate(90, center=(x + square_size / 2.0, y + square_size / 2.0))
+                sq_created.rotate(90, center=(x + square_size / 2, y + square_size / 2))
             dwg.add(sq_created)
     y += square_size
 

--- a/examples/ltattrie/tiling_part_4.py
+++ b/examples/ltattrie/tiling_part_4.py
@@ -45,16 +45,16 @@ def create_svg(name):
 
     defs_g_triright = dwg.defs.add(dwg.g(id='defs_g_triright', clip_path='url(#cliptriright)'))
     defs_g_triright.add(dwg.polygon([(0, 0), (triangle_size, 0), (triangle_size, triangle_size)], stroke='none'))
-    defs_g_triright.add(dwg.polygon([(3 * triangle_size / 4.0, 0), 
+    defs_g_triright.add(dwg.polygon([(3 * triangle_size / 4, 0),
         (triangle_size, 0), 
         (triangle_size, triangle_size)], stroke='none', fill='navy'))
-    defs_g_triright.add(dwg.circle(center=(triangle_size / 2.0, triangle_size / 2.0), r=5, stroke='blue', fill='green', stroke_width=1))
+    defs_g_triright.add(dwg.circle(center=(triangle_size / 2, triangle_size / 2), r=5, stroke='blue', fill='green', stroke_width=1))
 
     # define the mirror of  defs_g_triright
 
     defs_g_tr_m = dwg.defs.add(dwg.g(id='defs_g_tr_m'))
     defs_g_tr_m.add(dwg.use(defs_g_triright, insert=(0, 0)))
-    defs_g_tr_m.rotate(90, center=(triangle_size / 2.0, triangle_size / 2.0))
+    defs_g_tr_m.rotate(90, center=(triangle_size / 2, triangle_size / 2))
     defs_g_tr_m.translate(0, triangle_size)
     defs_g_tr_m.scale(1, -1)
 
@@ -103,7 +103,7 @@ def create_svg(name):
     # sin(30 degrees) is 1/2
 
     defs_g_rombus_size_x = square_size
-    defs_g_rombus_scale = defs_g_rombus_size_x / (sqrt3 * 2.0)
+    defs_g_rombus_scale = defs_g_rombus_size_x / (sqrt3 * 2)
     defs_g_rombus_size_y = 2 * defs_g_rombus_scale
 
     # Having a clip path seems to increase the visibility of the lines between the tiles.
@@ -111,17 +111,17 @@ def create_svg(name):
     # defs_g_rombus = dwg.defs.add(dwg.g(id='defs_g_rombus', clip_path='url(#cliprombus)'))
 
     defs_g_rombus = dwg.defs.add(dwg.g(id='defs_g_rombus'))
-    defs_g_rombus.add(dwg.polygon([(0, defs_g_rombus_size_y / 2.0), (defs_g_rombus_size_x / 2.0, 0), (0, -defs_g_rombus_size_y / 2),
-                      (-defs_g_rombus_size_x / 2.0, 0)], stroke='none'))
-    defs_g_rombus.add(dwg.polygon([(0, -defs_g_rombus_size_y / 2.0), (defs_g_rombus_size_x / 4.0, defs_g_rombus_size_y / 4.0), (0,
-                      defs_g_rombus_size_y / 2.0)], stroke='none', fill='darkolivegreen'))
+    defs_g_rombus.add(dwg.polygon([(0, defs_g_rombus_size_y / 2), (defs_g_rombus_size_x / 2, 0), (0, -defs_g_rombus_size_y / 2),
+                      (-defs_g_rombus_size_x / 2, 0)], stroke='none'))
+    defs_g_rombus.add(dwg.polygon([(0, -defs_g_rombus_size_y / 2), (defs_g_rombus_size_x / 4, defs_g_rombus_size_y / 4), (0,
+                      defs_g_rombus_size_y / 2)], stroke='none', fill='darkolivegreen'))
 
     #     (0, defs_g_rombus_size_y/2.0) ], stroke='none', fill='aqua'))
     #     (0, defs_g_rombus_size_y/2.0) ], stroke='none'))
     #     (defs_g_rombus_size_x/4.0, defs_g_rombus_size_y/4.0),
     #     (defs_g_rombus_size_x*invsqrt2_2/2.0, defs_g_rombus_size_y*invsqrt2_2/2.0),
 
-    defs_g_rombus.add(dwg.polygon([(0, -defs_g_rombus_size_y / 2.0), (-defs_g_rombus_size_x / 2.0, 0), (0, 0)], stroke='none', fill='palegreen'))
+    defs_g_rombus.add(dwg.polygon([(0, -defs_g_rombus_size_y / 2), (-defs_g_rombus_size_x / 2, 0), (0, 0)], stroke='none', fill='palegreen'))
 
     # Create rotations of the rombus.
 
@@ -135,11 +135,11 @@ def create_svg(name):
     # Create the pattern by using the cell and two rotated cells
 
     defs_g_rombus_pattern_size_x = defs_g_rombus_size_x
-    defs_g_rombus_pattern_size_y = 2.0 * defs_g_rombus_size_y
+    defs_g_rombus_pattern_size_y = 2 * defs_g_rombus_size_y
     defs_g_rombus_pattern = dwg.defs.add(dwg.g(id='defs_g_rombus_pattern'))
-    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus, insert=(defs_g_rombus_size_x / 2.0, 3 * defs_g_rombus_size_y / 2.0)))
-    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus_120, insert=(defs_g_rombus_size_x / 4.0, 3 * defs_g_rombus_size_y / 4.0)))
-    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus_m120, insert=(.75 * defs_g_rombus_size_x, 3 * defs_g_rombus_size_y / 4.0)))
+    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus, insert=(defs_g_rombus_size_x / 2, 3 * defs_g_rombus_size_y / 2)))
+    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus_120, insert=(defs_g_rombus_size_x / 4, 3 * defs_g_rombus_size_y / 4)))
+    defs_g_rombus_pattern.add(dwg.use(defs_g_rombus_m120, insert=(.75 * defs_g_rombus_size_x, 3 * defs_g_rombus_size_y / 4)))
 
     # ####################
     # p6 - Equilateral triangle
@@ -148,8 +148,8 @@ def create_svg(name):
     # The centre of the triangle is  sqrt(3)/6.0 * length of a side
 
     defs_g_trieq_size_x = square_size
-    defs_g_trieq_size_y = defs_g_trieq_size_x * sqrt3 / 2.0
-    defs_g_trieq_centre = sqrt3 / 6.0 * defs_g_trieq_size_x
+    defs_g_trieq_size_y = defs_g_trieq_size_x * sqrt3 / 2
+    defs_g_trieq_centre = sqrt3 / 6 * defs_g_trieq_size_x
 
     # width of equilateral triangle at the centre
 
@@ -158,28 +158,28 @@ def create_svg(name):
     # defs_g_trieq = dwg.defs.add(dwg.g(id='defs_g_trieq', clip_path='url(#cliptrieq)'))
 
     defs_g_trieq = dwg.defs.add(dwg.g(id='defs_g_trieq'))
-    defs_g_trieq.add(dwg.polygon([(0, -defs_g_trieq_size_y + defs_g_trieq_centre), (defs_g_trieq_size_x / 2.0, defs_g_trieq_centre),
-                     (-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)], stroke='none'))
-    defs_g_trieq.add(dwg.polygon([(-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre), (-defs_g_trieq_centre_size_x / 2.0, 0),
-                     (defs_g_trieq_centre_size_x / 2.0, 0), (0, defs_g_trieq_centre)], stroke='none', fill='yellow'))
+    defs_g_trieq.add(dwg.polygon([(0, -defs_g_trieq_size_y + defs_g_trieq_centre), (defs_g_trieq_size_x / 2, defs_g_trieq_centre),
+                     (-defs_g_trieq_size_x / 2, defs_g_trieq_centre)], stroke='none'))
+    defs_g_trieq.add(dwg.polygon([(-defs_g_trieq_size_x / 2, defs_g_trieq_centre), (-defs_g_trieq_centre_size_x / 2, 0),
+                     (defs_g_trieq_centre_size_x / 2, 0), (0, defs_g_trieq_centre)], stroke='none', fill='yellow'))
 
     # Create rotations of the equilateral triangle.
 
     defs_g_trieq_60 = dwg.defs.add(dwg.g(id='defs_g_trieq_60'))
     defs_g_trieq_60.add(dwg.use(defs_g_trieq, insert=(0, 0)))
-    defs_g_trieq_60.rotate(60, center=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre))
+    defs_g_trieq_60.rotate(60, center=(defs_g_trieq_size_x / 2, defs_g_trieq_centre))
     defs_g_trieq_120 = dwg.defs.add(dwg.g(id='defs_g_trieq_120'))
     defs_g_trieq_120.add(dwg.use(defs_g_trieq, insert=(0, 0)))
-    defs_g_trieq_120.rotate(120, center=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre))
+    defs_g_trieq_120.rotate(120, center=(defs_g_trieq_size_x / 2, defs_g_trieq_centre))
     defs_g_trieq_180 = dwg.defs.add(dwg.g(id='defs_g_trieq_180'))
     defs_g_trieq_180.add(dwg.use(defs_g_trieq, insert=(0, 0)))
-    defs_g_trieq_180.rotate(180, center=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre))
+    defs_g_trieq_180.rotate(180, center=(defs_g_trieq_size_x / 2, defs_g_trieq_centre))
     defs_g_trieq_m60 = dwg.defs.add(dwg.g(id='defs_g_trieq_m60'))
     defs_g_trieq_m60.add(dwg.use(defs_g_trieq, insert=(0, 0)))
-    defs_g_trieq_m60.rotate(-60, center=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre))
+    defs_g_trieq_m60.rotate(-60, center=(defs_g_trieq_size_x / 2, defs_g_trieq_centre))
     defs_g_trieq_m120 = dwg.defs.add(dwg.g(id='defs_g_trieq_m120'))
     defs_g_trieq_m120.add(dwg.use(defs_g_trieq, insert=(0, 0)))
-    defs_g_trieq_m120.rotate(-120, center=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre))
+    defs_g_trieq_m120.rotate(-120, center=(defs_g_trieq_size_x / 2, defs_g_trieq_centre))
 
     # Now use the cell and five rotated cells to create the pattern.
 
@@ -218,11 +218,11 @@ def create_svg(name):
     defs_g_trieq_pattern_v2_size_y = 2 * defs_g_trieq_size_y
     defs_g_trieq_pattern_v2 = dwg.defs.add(dwg.g(id='defs_g_trieq_pattern_v2'))
     defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq, insert=(0, defs_g_trieq_size_y - defs_g_trieq_centre)))
-    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_c60, insert=(-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)))
-    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_c120, insert=(-defs_g_trieq_size_x / 2.0, -defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_c60, insert=(-defs_g_trieq_size_x / 2, defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_c120, insert=(-defs_g_trieq_size_x / 2, -defs_g_trieq_centre)))
     defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_c180, insert=(0, defs_g_trieq_centre - defs_g_trieq_size_y)))
-    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_cm60, insert=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)))
-    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_cm120, insert=(defs_g_trieq_size_x / 2.0, -defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_cm60, insert=(defs_g_trieq_size_x / 2, defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v2.add(dwg.use(defs_g_trieq_cm120, insert=(defs_g_trieq_size_x / 2, -defs_g_trieq_centre)))
 
     # Now use the cell and five rotated cells to create the pattern variation 3.
     # Variation 3 is the equilateral triangle rotated around a the lower left corner.
@@ -230,12 +230,12 @@ def create_svg(name):
     defs_g_trieq_pattern_v3_size_x = 2 * defs_g_trieq_size_x
     defs_g_trieq_pattern_v3_size_y = 2 * defs_g_trieq_size_y
     defs_g_trieq_pattern_v3 = dwg.defs.add(dwg.g(id='defs_g_trieq_pattern_v3'))
-    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq, insert=(defs_g_trieq_size_x / 2.0, -defs_g_trieq_centre)))
-    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_c60, insert=(defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq, insert=(defs_g_trieq_size_x / 2, -defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_c60, insert=(defs_g_trieq_size_x / 2, defs_g_trieq_centre)))
     defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_c120, insert=(0, defs_g_trieq_size_y - defs_g_trieq_centre)))
-    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_c180, insert=(-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_c180, insert=(-defs_g_trieq_size_x / 2, defs_g_trieq_centre)))
     defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_cm60, insert=(0, defs_g_trieq_centre - defs_g_trieq_size_y)))
-    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_cm120, insert=(-defs_g_trieq_size_x / 2.0, -defs_g_trieq_centre)))
+    defs_g_trieq_pattern_v3.add(dwg.use(defs_g_trieq_cm120, insert=(-defs_g_trieq_size_x / 2, -defs_g_trieq_centre)))
 
     # ########################
     # Background will be dark but not black so the background does not overwhelm the colors.
@@ -292,12 +292,12 @@ def create_svg(name):
     dwg.add(pattern_created)
     y = y + defs_g_rombus_size_y
 
-    y_offset = defs_g_rombus_size_y / 2.0
+    y_offset = defs_g_rombus_size_y / 2
     for i in range(12):
         y += defs_g_rombus_pattern_size_y - y_offset
         for j in range(16):
             if i % 2:
-                x = 50 + defs_g_rombus_pattern_size_x / 2.0 + j * defs_g_rombus_pattern_size_x
+                x = 50 + defs_g_rombus_pattern_size_x / 2 + j * defs_g_rombus_pattern_size_x
             else:
                 x = 50 + j * defs_g_rombus_pattern_size_x
             pattern_created = dwg.use(defs_g_rombus_pattern, fill='black')
@@ -314,15 +314,15 @@ def create_svg(name):
     # Sample of tile.
 
     y = y + triangle_size
-    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2.0, y), fill='navy')
+    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2, y), fill='navy')
     dwg.add(tri_created)
-    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     tile_created = dwg.use(defs_g_trieq_pattern, insert=(150 + defs_g_trieq_pattern_size_x / 2, y), fill='navy')
     dwg.add(tile_created)
     dwg.add(dwg.circle(center=(150 + defs_g_trieq_pattern_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     y += defs_g_trieq_pattern_size_y
     for i in range(9):
-        y += defs_g_trieq_pattern_size_y / 2.0
+        y += defs_g_trieq_pattern_size_y / 2
         for j in range(6):
             if i % 2:
                 x = 50 + j * 1.5 * defs_g_trieq_pattern_size_x
@@ -339,9 +339,9 @@ def create_svg(name):
 
     # sample centered rotated eqilateral triangle variation 2
 
-    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2.0, y), fill='navy')
+    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2, y), fill='navy')
     dwg.add(tri_created)
-    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     tile_created = dwg.use(defs_g_trieq_c60, insert=(150 + defs_g_trieq_size_x / 2, y), fill='navy')
     dwg.add(tile_created)
     dwg.add(dwg.circle(center=(150 + defs_g_trieq_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
@@ -350,7 +350,7 @@ def create_svg(name):
     dwg.add(dwg.circle(center=(250 + defs_g_trieq_pattern_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     y += defs_g_trieq_pattern_size_y
     for i in range(9):
-        y += defs_g_trieq_pattern_v2_size_y / 2.0
+        y += defs_g_trieq_pattern_v2_size_y / 2
         for j in range(6):
             if i % 2:
                 x = 50 + j * 1.5 * defs_g_trieq_pattern_v2_size_x
@@ -367,9 +367,9 @@ def create_svg(name):
 
     # sample centered rotated eqilateral triangle variation 3
 
-    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2.0, y), fill='navy')
+    tri_created = dwg.use(defs_g_trieq, insert=(50 + defs_g_trieq_size_x / 2, y), fill='navy')
     dwg.add(tri_created)
-    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    dwg.add(dwg.circle(center=(50 + defs_g_trieq_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     tile_created = dwg.use(defs_g_trieq_c60, insert=(150 + defs_g_trieq_size_x / 2, y), fill='navy')
     dwg.add(tile_created)
     dwg.add(dwg.circle(center=(150 + defs_g_trieq_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
@@ -378,7 +378,7 @@ def create_svg(name):
     dwg.add(dwg.circle(center=(250 + defs_g_trieq_pattern_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     y += defs_g_trieq_pattern_size_y
     for i in range(9):
-        y += defs_g_trieq_pattern_v3_size_y / 2.0
+        y += defs_g_trieq_pattern_v3_size_y / 2
         for j in range(6):
             if i % 2:
                 x = 50 + j * 1.5 * defs_g_trieq_pattern_v3_size_x

--- a/examples/ltattrie/tiling_part_5.py
+++ b/examples/ltattrie/tiling_part_5.py
@@ -36,8 +36,8 @@ def create_svg(name):
     # The centre of the triangle is  sqrt(3)/6.0 * length of a side
 
     defs_g_trieq_size_x = square_size
-    defs_g_trieq_size_y = defs_g_trieq_size_x * sqrt3 / 2.0
-    defs_g_trieq_centre = sqrt3 / 6.0 * defs_g_trieq_size_x
+    defs_g_trieq_size_y = defs_g_trieq_size_x * sqrt3 / 2
+    defs_g_trieq_centre = sqrt3 / 6 * defs_g_trieq_size_x
 
     # width of equilateral triangle at the centre
 
@@ -46,10 +46,10 @@ def create_svg(name):
     # defs_g_trieq = dwg.defs.add(dwg.g(id='defs_g_trieq', clip_path='url(#cliptrieq)'))
 
     defs_g_trieq = dwg.defs.add(dwg.g(id='defs_g_trieq'))
-    defs_g_trieq.add(dwg.polygon([(0, -defs_g_trieq_size_y + defs_g_trieq_centre), (defs_g_trieq_size_x / 2.0, defs_g_trieq_centre),
-                     (-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre)], stroke='none'))
-    defs_g_trieq.add(dwg.polygon([(-defs_g_trieq_size_x / 2.0, defs_g_trieq_centre), (-defs_g_trieq_centre_size_x / 2.0, 0),
-                     (defs_g_trieq_centre_size_x / 2.0, 0), (0, defs_g_trieq_centre)], stroke='none', fill='yellow'))
+    defs_g_trieq.add(dwg.polygon([(0, -defs_g_trieq_size_y + defs_g_trieq_centre), (defs_g_trieq_size_x / 2, defs_g_trieq_centre),
+                     (-defs_g_trieq_size_x / 2, defs_g_trieq_centre)], stroke='none'))
+    defs_g_trieq.add(dwg.polygon([(-defs_g_trieq_size_x / 2, defs_g_trieq_centre), (-defs_g_trieq_centre_size_x / 2, 0),
+                     (defs_g_trieq_centre_size_x / 2, 0), (0, defs_g_trieq_centre)], stroke='none', fill='yellow'))
 
     # Create mirror of the equilateral triangle.
 
@@ -62,8 +62,8 @@ def create_svg(name):
     defs_g_trieq_cc_size_x = 1.5 * defs_g_trieq_size_x
     defs_g_trieq_cc_size_y = defs_g_trieq_size_y
     defs_g_trieq_cc = dwg.defs.add(dwg.g(id='defs_g_trieq_cc'))
-    defs_g_trieq_cc.add(dwg.use(defs_g_trieq, insert=(-defs_g_trieq_size_x / 4.0, defs_g_trieq_size_y / 2.0 - defs_g_trieq_centre)))
-    defs_g_trieq_cc.add(dwg.use(defs_g_trieq_m, insert=(defs_g_trieq_size_x / 4.0, -(defs_g_trieq_size_y / 2.0 - defs_g_trieq_centre))))
+    defs_g_trieq_cc.add(dwg.use(defs_g_trieq, insert=(-defs_g_trieq_size_x / 4, defs_g_trieq_size_y / 2 - defs_g_trieq_centre)))
+    defs_g_trieq_cc.add(dwg.use(defs_g_trieq_m, insert=(defs_g_trieq_size_x / 4, -(defs_g_trieq_size_y / 2 - defs_g_trieq_centre))))
 
     # Create rotations of combined cell
 
@@ -79,9 +79,9 @@ def create_svg(name):
     defs_g_trieq_pattern_size_x = 2 * defs_g_trieq_size_x
     defs_g_trieq_pattern_size_y = 2 * defs_g_trieq_size_y
     defs_g_trieq_pattern = dwg.defs.add(dwg.g(id='defs_g_trieq_pattern'))
-    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc, insert=(-defs_g_trieq_size_x / 4.0, -defs_g_trieq_cc_size_y / 2.0)))
-    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc_120, insert=(defs_g_trieq_size_x / 2.0, 0)))
-    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc_m120, insert=(-defs_g_trieq_size_x / 4.0, defs_g_trieq_cc_size_y / 2.0)))
+    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc, insert=(-defs_g_trieq_size_x / 4, -defs_g_trieq_cc_size_y / 2)))
+    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc_120, insert=(defs_g_trieq_size_x / 2, 0)))
+    defs_g_trieq_pattern.add(dwg.use(defs_g_trieq_cc_m120, insert=(-defs_g_trieq_size_x / 4, defs_g_trieq_cc_size_y / 2)))
 
     # ####################
     # p31m - Three rotations and a mirror
@@ -99,7 +99,7 @@ def create_svg(name):
     # The centre of equilateral triangle is  sqrt(3)/6.0 * length of a side
 
     defs_g_kite_size_x = square_size
-    defs_g_kite_size_y = defs_g_kite_size_x * sqrt3 / 2.0 + defs_g_kite_size_x * sqrt3 / 6.0
+    defs_g_kite_size_y = defs_g_kite_size_x * sqrt3 / 2 + defs_g_kite_size_x * sqrt3 / 6
 
     # Having a clip path seems to increase the visibility of the lines between the tiles.
     # A clipping path may be necessary if the shapes go outside the triangle.
@@ -107,21 +107,21 @@ def create_svg(name):
 
     defs_g_kite = dwg.defs.add(dwg.g(id='defs_g_kite'))
     defs_g_kite.add(dwg.polygon([(0, 0), 
-        (defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0)), 
+        (defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2)),
         (0, defs_g_kite_size_y), 
-        (-defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0))], stroke='none'))
+        (-defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2))], stroke='none'))
     #defs_g_kite.add(dwg.polygon([(0, 0), 
     #    (defs_g_kite_size_x / 4.0, (defs_g_kite_size_y + defs_g_kite_size_x / (sqrt3 * 2.0)) / 2.0),
     #    (-defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0))], stroke='none', fill='yellow'))
     defs_g_kite.add(dwg.polygon([(0, 0), 
-        (defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0)),
-        (0, defs_g_kite_size_y / 12.0),
-        (-defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0))], stroke='none',
+        (defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2)),
+        (0, defs_g_kite_size_y / 12),
+        (-defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2))], stroke='none',
         fill='black'))
     defs_g_kite.add(dwg.polygon([(0, defs_g_kite_size_y), 
-        (defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0)),
-        (0, defs_g_kite_size_y * 8.0 / 12.0),
-        (-defs_g_kite_size_x / 2.0, defs_g_kite_size_x / (sqrt3 * 2.0))], stroke='none',
+        (defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2)),
+        (0, defs_g_kite_size_y * 8 / 12),
+        (-defs_g_kite_size_x / 2, defs_g_kite_size_x / (sqrt3 * 2))], stroke='none',
         fill='green'))
 
     # Create rotations of the kite.
@@ -154,8 +154,8 @@ def create_svg(name):
     defs_g_kite_pattern_size_x = 1.5 * defs_g_kite_cc_size_x
     defs_g_kite_pattern_size_y = defs_g_kite_cc_size_y
     defs_g_kite_pattern = dwg.defs.add(dwg.g(id='defs_g_kite_pattern'))
-    defs_g_kite_pattern.add(dwg.use(defs_g_kite_cc, insert=(-defs_g_kite_cc_size_x / 4.0, -sqrt3 / 12.0 * defs_g_kite_cc_size_x)))
-    defs_g_kite_pattern.add(dwg.use(defs_g_kite_mcc, insert=(defs_g_kite_cc_size_x / 4.0, sqrt3 / 12.0 * defs_g_kite_cc_size_x)))
+    defs_g_kite_pattern.add(dwg.use(defs_g_kite_cc, insert=(-defs_g_kite_cc_size_x / 4, -sqrt3 / 12 * defs_g_kite_cc_size_x)))
+    defs_g_kite_pattern.add(dwg.use(defs_g_kite_mcc, insert=(defs_g_kite_cc_size_x / 4, sqrt3 / 12 * defs_g_kite_cc_size_x)))
 
     # ####################
     # p6m - Kaleidoscope Either of the two long sides of the primary triangle is mirrored.  The
@@ -172,7 +172,7 @@ def create_svg(name):
     # # The centre of equilateral triangle is  sqrt(3) / 6.0 * length of a side
 
     defs_g_kale_tri_size_x = square_size
-    defs_g_kale_tri_size_y = defs_g_kale_tri_size_x * 4.0 / sqrt3
+    defs_g_kale_tri_size_y = defs_g_kale_tri_size_x * 4 / sqrt3
 
     # Having a clip path seems to increase the visibility of the lines between the tiles.
     # A clipping path may be necessary if the shapes go outside the triangle.
@@ -181,8 +181,8 @@ def create_svg(name):
     defs_g_kale_tri = dwg.defs.add(dwg.g(id='defs_g_kale_tri'))
     defs_g_kale_tri.add(dwg.polygon([(0, -defs_g_kale_tri_size_y), (0, 0), (-defs_g_kale_tri_size_x, defs_g_kale_tri_size_x / sqrt3
                         - defs_g_kale_tri_size_y)], stroke='none'))
-    defs_g_kale_tri.add(dwg.polygon([(-defs_g_kale_tri_size_x, defs_g_kale_tri_size_x / sqrt3 - defs_g_kale_tri_size_y), (0, 2.0
-                        * defs_g_kale_tri_size_x / sqrt3 - defs_g_kale_tri_size_y), (0, 3.0 * defs_g_kale_tri_size_x / sqrt3
+    defs_g_kale_tri.add(dwg.polygon([(-defs_g_kale_tri_size_x, defs_g_kale_tri_size_x / sqrt3 - defs_g_kale_tri_size_y), (0, 2
+                        * defs_g_kale_tri_size_x / sqrt3 - defs_g_kale_tri_size_y), (0, 3 * defs_g_kale_tri_size_x / sqrt3
                         - defs_g_kale_tri_size_y)], stroke='none', fill='yellow'))
 
     # Create mirror of the kale.
@@ -256,7 +256,7 @@ def create_svg(name):
     dwg.add(dwg.circle(center=(250 + defs_g_trieq_cc_size_x, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     y += defs_g_trieq_pattern_size_y
     for i in range(8):
-        y += defs_g_trieq_pattern_size_y / 2.0
+        y += defs_g_trieq_pattern_size_y / 2
         for j in range(6):
             if i % 2:
                 x = 50 + j * 1.5 * defs_g_trieq_pattern_size_x
@@ -273,12 +273,12 @@ def create_svg(name):
     title2 = 'Kite rotated and mirrored, math name: p31m'
     dwg.add(dwg.text(title2, insert=(50, y), font_family='serif', font_size=font_size, fill='white'))
     y = y + font_size + defs_g_kite_size_y
-    cell_created = dwg.use(defs_g_kite, insert=(50 + defs_g_kite_size_x / 2.0, y), fill='navy')
+    cell_created = dwg.use(defs_g_kite, insert=(50 + defs_g_kite_size_x / 2, y), fill='navy')
     dwg.add(cell_created)
-    dwg.add(dwg.circle(center=(50 + defs_g_kite_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
-    cc_created = dwg.use(defs_g_kite_cc, insert=(150 + defs_g_kite_size_x / 2.0, y), fill='navy')
+    dwg.add(dwg.circle(center=(50 + defs_g_kite_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    cc_created = dwg.use(defs_g_kite_cc, insert=(150 + defs_g_kite_size_x / 2, y), fill='navy')
     dwg.add(cc_created)
-    dwg.add(dwg.circle(center=(150 + defs_g_kite_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    dwg.add(dwg.circle(center=(150 + defs_g_kite_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
     mcc_created = dwg.use(defs_g_kite_mcc, insert=(250 + defs_g_kite_cc_size_x / 2, y), fill='navy')
     dwg.add(mcc_created)
     dwg.add(dwg.circle(center=(250 + defs_g_kite_cc_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
@@ -308,13 +308,13 @@ def create_svg(name):
     cell_created = dwg.use(defs_g_kale_tri, insert=(50 + defs_g_kale_tri_size_x, y), fill='navy')
     dwg.add(cell_created)
     dwg.add(dwg.circle(center=(50 + defs_g_kale_tri_size_x, y), r=3, stroke='none', fill='purple', opacity='0.5'))
-    cc_created = dwg.use(defs_g_kale_cc, insert=(150 + defs_g_kale_cc_size_x / 2.0, y), fill='navy')
+    cc_created = dwg.use(defs_g_kale_cc, insert=(150 + defs_g_kale_cc_size_x / 2, y), fill='navy')
     dwg.add(cc_created)
-    dwg.add(dwg.circle(center=(150 + defs_g_kale_cc_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
-    pattern_created = dwg.use(defs_g_kale_pattern, insert=(250 + defs_g_kale_pattern_size_x / 2.0, y), fill='navy')
+    dwg.add(dwg.circle(center=(150 + defs_g_kale_cc_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    pattern_created = dwg.use(defs_g_kale_pattern, insert=(250 + defs_g_kale_pattern_size_x / 2, y), fill='navy')
     dwg.add(pattern_created)
-    dwg.add(dwg.circle(center=(250 + defs_g_kale_pattern_size_x / 2.0, y), r=3, stroke='none', fill='purple', opacity='0.5'))
-    y += defs_g_kale_pattern_size_y / 2.0
+    dwg.add(dwg.circle(center=(250 + defs_g_kale_pattern_size_x / 2, y), r=3, stroke='none', fill='purple', opacity='0.5'))
+    y += defs_g_kale_pattern_size_y / 2
     for i in range(4):
         y += defs_g_kale_pattern_size_y - defs_g_kale_pattern_size_x / (sqrt3 * 2)
         for j in range(6):

--- a/examples/ltattrie/xkcd_colour_data_svgwrite_3.py
+++ b/examples/ltattrie/xkcd_colour_data_svgwrite_3.py
@@ -88,7 +88,7 @@ def create_svg(name):
         #hsl =
         #h, l, s = colorsys.rgb_to_hls(r, g, b)
         # rgb values are integer but colorsys wants float(0..1) and returns float
-        h, l, s = colorsys.rgb_to_hls(rgb[0]/255.0, rgb[1]/255.0, rgb[2]/255.0)
+        h, l, s = colorsys.rgb_to_hls(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255)
         hsl = (h, s, l)
         swatch_x=int(h*1000)
         # hue by lightness

--- a/examples/mandelbrot.py
+++ b/examples/mandelbrot.py
@@ -50,7 +50,7 @@ def mandelbrot(name):
             z = zx + zy * 1j
             c = z
             for i in range(maxIt):
-                if abs(z) > 2.0: break
+                if abs(z) > 2: break
                 z = z * z + c
             putpixel((x, y), rgb(i % 4 * 64, i % 8 * 32, i % 16 * 16))
     dwg.save()

--- a/svgwrite/extensions/shapes.py
+++ b/svgwrite/extensions/shapes.py
@@ -23,14 +23,14 @@ def ngon(num_corners, edge_length=None, radius=None, rotation=0.):
     if num_corners < 3:
         raise ValueError('Argument `num_corners` has to be greater than 2.')
     if edge_length is not None:
-        radius = edge_length / 2. / math.sin(math.pi / num_corners)
+        radius = edge_length / 2 / math.sin(math.pi / num_corners)
     elif radius is not None:
         if radius <= 0.:
             raise ValueError('Argument `radius` has to be greater than 0.')
     else:
         raise ValueError('Argument `edge_length` or `radius` required.')
 
-    delta = 2. * math.pi / num_corners
+    delta = 2 * math.pi / num_corners
     angle = rotation
     for _ in range(num_corners):
         yield (radius * math.cos(angle), radius * math.sin(angle))
@@ -126,6 +126,4 @@ def centroid(vertices):
         c_x += x
         c_y += y
         k += 1
-    c_x = float(c_x / k)
-    c_y = float(c_y / k)
-    return c_x, c_y
+    return c_x / k, c_y / k

--- a/svgwrite/gradients.py
+++ b/svgwrite/gradients.py
@@ -69,10 +69,8 @@ class _AbstractGradient(BaseElement, Transform, XLink):
           'red': offset = 0.5
           'blue': offset = 1.0
         """
-        start = float(sweep[0])
-        end = float(sweep[1])
-        delta = (end-start) / float(len(colors) - 1)
-        offset = start
+        delta = (sweep[1] - sweep[0]) / (len(colors) - 1)
+        offset = sweep[0]
         for color in colors:
             self.add_stop_color(round(offset, 3), color, opacity)
             offset += delta

--- a/tests/test_full11_typechecker.py
+++ b/tests/test_full11_typechecker.py
@@ -21,15 +21,15 @@ class TestFull11TypeChecker(unittest.TestCase):
     def test_is_anything(self):
         """ Everything is valid. """
         self.assertTrue(self.checker.is_anything('abcdef  :::\n \r \t all is valid äüß'))
-        self.assertTrue(self.checker.is_anything(100.0))
-        self.assertTrue(self.checker.is_anything((100.0, 11)))
+        self.assertTrue(self.checker.is_anything(100))
+        self.assertTrue(self.checker.is_anything((100, 11)))
         self.assertTrue(self.checker.is_anything(dict(a=100, b=200)))
 
     def test_is_string(self):
         """ Everything is valid. """
         self.assertTrue(self.checker.is_anything('abcdef  :::\n \r \t all is valid äüß'))
-        self.assertTrue(self.checker.is_anything(100.0))
-        self.assertTrue(self.checker.is_anything((100.0, 11)))
+        self.assertTrue(self.checker.is_anything(100))
+        self.assertTrue(self.checker.is_anything((100, 11)))
         self.assertTrue(self.checker.is_anything(dict(a=100, b=200)))
         self.assertTrue(self.checker.is_anything(u'äüß'.encode('utf-8')))
 


### PR DESCRIPTION
In Python3 `a/b` for two integers always returns a float, so there is no need to convert `a` or `b` to floats beforehand if they are actually integers.

Also `math.sqrt(a ** 2 + b ** 2)` can be replaced with `math.hypot(a, b)`. 