### PR TITLE
Apply `pyupgrade --py36-plus` to examples,svgwrite,tests

### DIFF
--- a/examples/LSystem.py
+++ b/examples/LSystem.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/basic_shapes.py
+++ b/examples/basic_shapes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 07.11.2010

--- a/examples/checkerboard.py
+++ b/examples/checkerboard.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg example: inline stylesheets, css, viewbox, groups
 # Created: 09.06.2012

--- a/examples/hyperlink.py
+++ b/examples/hyperlink.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg hyperlink examples
 # Created: 05.05.2017

--- a/examples/inkscape_drawing.py
+++ b/examples/inkscape_drawing.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  ao2
 # Purpose: create Inkscape layers with svgwrite
 # Created: 26.01.2018
@@ -16,7 +15,7 @@ class InkscapeDrawing(svgwrite.Drawing):
     SODIPODI_NAMESPACE = 'http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd'
 
     def __init__(self, *args, **kwargs):
-        super(InkscapeDrawing, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         inkscape_attributes = {
             'xmlns:inkscape': SVGAttribute('xmlns:inkscape',

--- a/examples/koch_snowflake.py
+++ b/examples/koch_snowflake.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/linearGradient.py
+++ b/examples/linearGradient.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/ltattrie/bezier.py
+++ b/examples/ltattrie/bezier.py
@@ -21,7 +21,7 @@ def nfrange(fstart, fstop, n):
     return [ fstart + delta * i for i in range(n) ]
 
 def create_svg(name):
-    class bezier(object):
+    class bezier:
         def __init__(self, val_x, val_y):
             # The main point
             self.x = val_x
@@ -36,26 +36,26 @@ def create_svg(name):
         def displayf(self):
             # display formatted with brackets and commas
             if self.cbx:
-                self.s_cb = '({:f}, {:f})'.format(self.cbx, self.cby)
+                self.s_cb = f'({self.cbx:f}, {self.cby:f})'
             else:
                 self.s_cb = '(None, None)'
             if self.cax:
-                self.s_ca = '({:f}, {:f})'.format(self.cax, self.cay)
+                self.s_ca = f'({self.cax:f}, {self.cay:f})'
             else:
                 self.s_ca = ' (None, None)'
-            return '({:s}, ({:f}, {:f}), {:s})'.format(self.s_cb, self.x, self.y, self.s_ca)
+            return f'({self.s_cb:s}, ({self.x:f}, {self.y:f}), {self.s_ca:s})'
 
         def display(self):
             # display without formatted with brackets and commas
             if self.cbx:
-                self.s_cb = '{:f} {:f}'.format(self.cbx, self.cby)
+                self.s_cb = f'{self.cbx:f} {self.cby:f}'
             else:
                 self.s_cb = 'None None'
             if self.cax:
-                self.s_ca = '{:f} {:f}'.format(self.cax, self.cay)
+                self.s_ca = f'{self.cax:f} {self.cay:f}'
             else:
                 self.s_ca = ' None None'
-            return '{:s} {:f} {:f} {:s}'.format(self.s_cb, self.x, self.y, self.s_ca)
+            return f'{self.s_cb:s} {self.x:f} {self.y:f} {self.s_ca:s}'
 
     svg_size = 900
     font_size = 20

--- a/examples/ltattrie/tiling_part_1.py
+++ b/examples/ltattrie/tiling_part_1.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
 # Author:  L. Tattrie
 # Purpose: svgwrite examples

--- a/examples/ltattrie/tiling_part_2.py
+++ b/examples/ltattrie/tiling_part_2.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 # Author:  L. Tattrie
 # Purpose: svgwrite examples

--- a/examples/ltattrie/tiling_part_3.py
+++ b/examples/ltattrie/tiling_part_3.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 # Author:  L. Tattrie
 # Purpose: svgwrite examples

--- a/examples/ltattrie/tiling_part_4.py
+++ b/examples/ltattrie/tiling_part_4.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 # Author:  L. Tattrie
 # Purpose: svgwrite examples

--- a/examples/ltattrie/tiling_part_5.py
+++ b/examples/ltattrie/tiling_part_5.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 # Author:  L. Tattrie
 # Purpose: svgwrite examples

--- a/examples/mandelbrot.py
+++ b/examples/mandelbrot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/marker.py
+++ b/examples/marker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/pattern.py
+++ b/examples/pattern.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/radialGradient.py
+++ b/examples/radialGradient.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/simple_text.py
+++ b/examples/simple_text.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/solidcolor.py
+++ b/examples/solidcolor.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 26.10.2016

--- a/examples/use.py
+++ b/examples/use.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg examples
 # Created: 08.09.2010

--- a/examples/using_bitmap_images.py
+++ b/examples/using_bitmap_images.py
@@ -14,7 +14,7 @@ img = Image(filename="my.png")
 # Then get raw PNG data and encode DIRECTLY into the SVG file.
 image_data = img.make_blob(format='png')
 encoded = base64.b64encode(image_data).decode()
-pngdata = 'data:image/png;base64,{}'.format(encoded)
+pngdata = f'data:image/png;base64,{encoded}'
 
 image = dwg.add(dwg.image(href=(pngdata)))
 
@@ -28,6 +28,6 @@ img = Image(filename="my.svg")
 # Then get raw SVG data and encode DIRECTLY into the SVG file.
 image_data = img.make_blob()  # Don't change its format, just use it as an SVG
 encoded = base64.b64encode(image_data).decode()
-svgdata = 'data:image/svg+xml;base64,{}'.format(encoded)
+svgdata = f'data:image/svg+xml;base64,{encoded}'
 
 image = dwg.add(dwg.image(href=(svgdata)))

--- a/examples/using_fonts.py
+++ b/examples/using_fonts.py
@@ -2,7 +2,7 @@ import svgwrite
 
 
 def write_html_loader(name, title):
-    open('{name}.html'.format(name=name), 'wt', encoding='utf-8').write("""<!DOCTYPE html>
+    open(f'{name}.html', 'wt', encoding='utf-8').write("""<!DOCTYPE html>
     <html>
     <head>
         <meta charset="UTF-8">

--- a/examples/using_shapes_extension.py
+++ b/examples/using_shapes_extension.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  ya-induhvidual
 # Purpose: svg shapes-extension example
 # Modified

--- a/svgwrite/__init__.py
+++ b/svgwrite/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: package definition file
 # Created: 08.09.2010
@@ -54,7 +53,7 @@ from svgwrite.drawing import Drawing
 from svgwrite.utils import rgb
 
 
-class Unit(object):
+class Unit:
     """ Add units to values.
     """
     def __init__(self, unit='cm'):
@@ -66,7 +65,7 @@ class Unit(object):
 
     def __rmul__(self, other):
         """ add unit-string to 'other'. (e.g. 5*cm => '5cm') """
-        return "%s%s" % (other, self._unit)
+        return f"{other}{self._unit}"
 
     def __call__(self, *args):
         """ Add unit-strings to all arguments.
@@ -74,7 +73,7 @@ class Unit(object):
         :param args: list of values
             e.g.: cm(1,2,3) => '1cm,2cm,3cm'
         """
-        return ','.join(["%s%s" % (arg, self._unit) for arg in args])
+        return ','.join([f"{arg}{self._unit}" for arg in args])
 
 
 cm = Unit('cm')

--- a/svgwrite/animate.py
+++ b/svgwrite/animate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: animate elements
 # Created: 31.10.2010
@@ -26,13 +25,13 @@ class Set(BaseElement, XLink):
         :param href: target svg element, if **href** is not `None`; else
             the target SVG Element is the parent SVG Element.
         """
-        super(Set, self).__init__(**extra)
+        super().__init__(**extra)
         if href is not None:
             self.set_href(href)
 
     def get_xml(self):
         self.update_id() # if href is an object - 'id' - attribute may be changed!
-        return super(Set, self).get_xml()
+        return super().get_xml()
 
     def set_target(self, attributeName, attributeType=None):
         """
@@ -98,7 +97,7 @@ class AnimateMotion(Set):
         :param href: target svg element, if **href** is not `None`; else
           the target SVG Element is the parent SVG Element.
         """
-        super(AnimateMotion, self).__init__(href=href, **extra)
+        super().__init__(href=href, **extra)
         if path is not None:
             self['path'] = path
 
@@ -129,7 +128,7 @@ class Animate(Set):
         :param href: target svg element, if **href** is not `None`; else
           the target SVG Element is the parent SVG Element.
         """
-        super(Animate, self).__init__(href=href, **extra)
+        super().__init__(href=href, **extra)
         if values is not None:
             self.set_value(values)
         if attributeName is not None:
@@ -179,5 +178,5 @@ class AnimateTransform(Animate):
           the target svg element is the parent svg element.
         :param string transform: ``'translate | scale | rotate | skewX | skewY'``
         """
-        super(AnimateTransform, self).__init__(element, **extra)
+        super().__init__(element, **extra)
         self['type'] = transform

--- a/svgwrite/base.py
+++ b/svgwrite/base.py
@@ -1,5 +1,4 @@
 ﻿#!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg base element
 # Created: 08.09.2010
@@ -17,7 +16,7 @@ from svgwrite.params import Parameter
 from svgwrite.utils import AutoID
 
 
-class BaseElement(object):
+class BaseElement:
     """
     The **BaseElement** is the root for all SVG elements. The SVG attributes
     are stored in **attribs**, and the SVG subelements are stored in
@@ -256,7 +255,7 @@ class BaseElement(object):
             self.elements.insert(pos, metadata)
 
 
-class Title(object):
+class Title:
     elementname = 'title'
 
     def __init__(self, text):

--- a/svgwrite/container.py
+++ b/svgwrite/container.py
@@ -1,4 +1,3 @@
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg container classes
 # Created: 15.09.2010
@@ -85,7 +84,7 @@ class Marker(BaseElement, ViewBox, Presentation):
         :param orient: ``'auto'`` | `angle`
         :param extra: additional SVG attributes as keyword-arguments
         """
-        super(Marker, self).__init__(**extra)
+        super().__init__(**extra)
         if insert is not None:
             self['refX'] = insert[0]
             self['refY'] = insert[1]
@@ -122,7 +121,7 @@ class SVG(Symbol):
         :param 2-tuple size: (**width**, **height**)
         :param extra: additional SVG attributes as keyword-arguments
         """
-        super(SVG, self).__init__(**extra)
+        super().__init__(**extra)
         if insert is not None:
             self['x'] = insert[0]
             self['y'] = insert[1]
@@ -159,7 +158,7 @@ class SVG(Symbol):
         font_info = urlopen(uri).read()
         font_url = find_first_url(font_info.decode())
         if font_url is None:
-            raise ValueError("Got no font data from uri: '{}'".format(uri))
+            raise ValueError(f"Got no font data from uri: '{uri}'")
         else:
             data = urlopen(font_url).read()
             self._embed_font_data(name, data, font_mimetype(font_url))
@@ -187,7 +186,7 @@ class Use(BaseElement, Transform, XLink, Presentation):
         :param 2-tuple size: (**width**, **height**)
         :param extra: additional SVG attributes as keyword-arguments
         """
-        super(Use, self).__init__(**extra)
+        super().__init__(**extra)
         self.set_href(href)
         if insert is not None:
             self['x'] = insert[0]
@@ -198,7 +197,7 @@ class Use(BaseElement, Transform, XLink, Presentation):
 
     def get_xml(self):
         self.update_id()  # if href is an object - 'id' - attribute may be changed!
-        return super(Use, self).get_xml()
+        return super().get_xml()
 
 
 class Hyperlink(BaseElement, Transform, Presentation):
@@ -225,7 +224,7 @@ class Hyperlink(BaseElement, Transform, Presentation):
         :param string target: ``'_blank|_replace|_self|_parent|_top|<XML-name>'``
         :param extra: additional SVG attributes as keyword-arguments
         """
-        super(Hyperlink, self).__init__(**extra)
+        super().__init__(**extra)
         self['xlink:href'] = href
         if target is not None:
             self['target'] = target
@@ -254,13 +253,13 @@ class Script(BaseElement):
 
         """
         # removed type parameter, default is "application/ecmascript"
-        super(Script, self).__init__(**extra)
+        super().__init__(**extra)
         if href is not None:
             self['xlink:href'] = href
         self._content = content
 
     def get_xml(self):
-        xml = super(Script, self).get_xml()
+        xml = super().get_xml()
         if self._content:
             xml.append(CDATA(self._content))
         return xml
@@ -282,6 +281,6 @@ class Style(Script):
         """
         :param string content: stylesheet content
         """
-        super(Style, self).__init__(content=content, **extra)
+        super().__init__(content=content, **extra)
         self['type'] = "text/css"
 

--- a/svgwrite/data/colors.py
+++ b/svgwrite/data/colors.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: colornames
 # Created: 06.10.2010

--- a/svgwrite/data/full11.py
+++ b/svgwrite/data/full11.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: full11 data
 # Created: 15.10.2010

--- a/svgwrite/data/pattern.py
+++ b/svgwrite/data/pattern.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: pattern module
 # Created: 27.09.2010

--- a/svgwrite/data/svgparser.py
+++ b/svgwrite/data/svgparser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Authors:  mozman <me@mozman.at>, Florian Festi
 # Purpose: svgparser using re module
 # Created: 16.10.2010
@@ -49,8 +48,8 @@ def build_transferlist_parser():
     skewX = fr"skewX\s*\(\s*{number}\s*\)"
     skewY = fr"skewY\s*\(\s*{number}\s*\)"
 
-    tl_re = "|".join((fr"(\s*{cmd}\s*)" for cmd in (
-        matrix, translate, scale, rotate, skewX, skewY)))
+    tl_re = "|".join(fr"(\s*{cmd}\s*)" for cmd in (
+        matrix, translate, scale, rotate, skewX, skewY))
     return fr"({tl_re})({c}({tl_re}))*"
 
 
@@ -78,10 +77,10 @@ def build_pathdata_parser():
     elliptical_arc_argument = r"\s*" + elliptical_arc_argument + r"\s*"
     elliptical_arc = fr"[aA]({elliptical_arc_argument})({c}{elliptical_arc_argument})*"
 
-    drawto_command = "|".join((fr"(\s*{cmd}\s*)" for cmd in (
+    drawto_command = "|".join(fr"(\s*{cmd}\s*)" for cmd in (
         moveto, lineto, horizontal_lineto, vertical_lineto, "[zZ]",
         curveto, smooth_curveto, quadratic_bezier_curveto,
-        smooth_quadratic_bezier_curveto, elliptical_arc)))
+        smooth_quadratic_bezier_curveto, elliptical_arc))
 
     return f"{moveto}({drawto_command})*"
 
@@ -122,9 +121,9 @@ def build_animation_timing_parser():
     event_value = fr"({id_value}\.)?{event_ref}([+-]?{clock_val})?"
     offset_value = fr"[-+]?{clock_val}"
     syncbase_value = fr"{id_value}\.(begin|end)({offset_value})?"
-    begin_value = "(" + "|".join((f"({reg})" for reg in (
+    begin_value = "(" + "|".join(f"({reg})" for reg in (
         offset_value, syncbase_value, event_value, repeat_value,
-        accesskey_value, wallclock_sync_value, "indefinite"))) + ")"
+        accesskey_value, wallclock_sync_value, "indefinite")) + ")"
     return fr"{begin_value}({c}{begin_value})*"
 
 

--- a/svgwrite/data/tiny12.py
+++ b/svgwrite/data/tiny12.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: tiny12 data
 # Created: 15.10.2010

--- a/svgwrite/data/typechecker.py
+++ b/svgwrite/data/typechecker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: typechecker
 # Created: 15.10.2010
@@ -17,8 +16,7 @@ def iterflatlist(values):
     """ Flatten nested *values*, returns an *iterator*. """
     for element in values:
         if hasattr(element, "__iter__") and not is_string(element):
-            for item in iterflatlist(element):
-                yield item
+            yield from iterflatlist(element)
         else:
             yield element
 
@@ -33,7 +31,7 @@ COLOR_RGB_PERCENTAGE_PATTERN = re.compile(r"^rgb\( *\d+(\.\d*)?% *, *\d+(\.\d*)?
 NMTOKEN_PATTERN = re.compile(r"^[a-zA-Z_:][\w\-\.:]*$")
 
 
-class Full11TypeChecker(object):
+class Full11TypeChecker:
     def get_version(self):
         return '1.1', 'full'
 
@@ -152,7 +150,7 @@ class Full11TypeChecker(object):
     def is_four_numbers(self, value):
         def split(value):
             if is_string(value):
-                values = iterflatlist( (v.strip().split(' ') for v in value.split(',')) )
+                values = iterflatlist( v.strip().split(' ') for v in value.split(',') )
                 return (v for v in values if v)
             else:
                 return iterflatlist(value)

--- a/svgwrite/data/types.py
+++ b/svgwrite/data/types.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: svg types
 # Created: 30.09.2010
@@ -7,7 +6,7 @@
 # License: MIT License
 
 
-class SVGAttribute(object):
+class SVGAttribute:
     def __init__(self, name, anim, types, const):
         self.name = name
         self._anim = anim
@@ -27,7 +26,7 @@ class SVGAttribute(object):
         return self._const
 
 
-class SVGMultiAttribute(object):
+class SVGMultiAttribute:
     # example: SVGMultiAttribute({'*':SVGAttribute(...), 'text tref':SVGAttribute(...)} )
     # parametr is a dict-like object
     # '*' is the default attribute definition
@@ -72,7 +71,7 @@ class SVGMultiAttribute(object):
         return attribute.get_const()
 
 
-class SVGElement(object):
+class SVGElement:
     def __init__(self, name, attributes, properties, children):
         self.name = name
         s = set(attributes)

--- a/svgwrite/drawing.py
+++ b/svgwrite/drawing.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: drawing
 # Created: 10.09.2010
@@ -52,7 +51,7 @@ class Drawing(SVG, ElementFactory):
         :param bool debug: switch validation on/off
 
         """
-        super(Drawing, self).__init__(size=size, **extra)
+        super().__init__(size=size, **extra)
         self.filename = filename
         self._stylesheets = []  # list of stylesheets appended
 
@@ -70,7 +69,7 @@ class Drawing(SVG, ElementFactory):
 
         self.attribs['baseProfile'] = profile
         self.attribs['version'] = version
-        return super(Drawing, self).get_xml()
+        return super().get_xml()
 
     def add_stylesheet(self, href, title, alternate="no", media="screen"):
         """ Add a stylesheet reference.
@@ -117,7 +116,7 @@ class Drawing(SVG, ElementFactory):
         :param pretty: True for easy readable output
         :param indent: how much to indent if pretty is enabled, by default 2 spaces
         """
-        fileobj = io.open(self.filename, mode='w', encoding='utf-8')
+        fileobj = open(self.filename, mode='w', encoding='utf-8')
         self.write(fileobj, pretty=pretty, indent=indent)
         fileobj.close()
 

--- a/svgwrite/elementfactory.py
+++ b/svgwrite/elementfactory.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: element factory
 # Created: 15.10.2010
@@ -56,7 +55,7 @@ factoryelements = {
 }
 
 
-class ElementBuilder(object):
+class ElementBuilder:
     def __init__(self, cls, factory):
         self.cls = cls
         self.factory = factory
@@ -68,9 +67,9 @@ class ElementBuilder(object):
         return self.cls(*args, **kwargs)
 
 
-class ElementFactory(object):
+class ElementFactory:
     def __getattr__(self, name):
         if name in factoryelements:
             return ElementBuilder(factoryelements[name], self)
         else:
-            raise AttributeError("'%s' has no attribute '%s'" % (self.__class__.__name__, name))
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")

--- a/svgwrite/etree.py
+++ b/svgwrite/etree.py
@@ -1,5 +1,4 @@
 ﻿#!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: a hack to generate XML containing CDATA by ElementTree
 # Created: 26.05.2012

--- a/svgwrite/extensions/inkscape.py
+++ b/svgwrite/extensions/inkscape.py
@@ -60,7 +60,7 @@ LABEL = 'inkscape:label'
 INSENSITIVE = 'sodipodi:insensitive'
 
 
-class Inkscape(object):
+class Inkscape:
     """
     Extension to support SOME Inkscape features.
 

--- a/svgwrite/filters.py
+++ b/svgwrite/filters.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: filters module
 # Created: 03.11.2010
@@ -17,7 +16,7 @@ class _feDistantLight(BaseElement):
     elementname = 'feDistantLight'
 
     def __init__(self, azimuth=0, elevation=0, **extra):
-        super(_feDistantLight, self).__init__(**extra)
+        super().__init__(**extra)
         if azimuth != 0:
             self['azimuth'] = azimuth
         if elevation != 0:
@@ -28,7 +27,7 @@ class _fePointLight(BaseElement):
     elementname = 'fePointLight'
 
     def __init__(self, source=(0, 0, 0), **extra):
-        super(_fePointLight, self).__init__(**extra)
+        super().__init__(**extra)
         x, y, z = source
         if x != 0:
             self['x'] = x
@@ -42,7 +41,7 @@ class _feSpotLight(_fePointLight):
     elementname = 'feSpotLight'
 
     def __init__(self, source=(0, 0, 0), target=(0, 0, 0), **extra):
-        super(_feSpotLight, self).__init__(source, **extra)
+        super().__init__(source, **extra)
         x, y, z = target
         if x != 0:
             self['pointsAtX'] = x
@@ -58,7 +57,7 @@ class _FilterPrimitive(BaseElement, Presentation):
 
 class _FilterNoInput(_FilterPrimitive):
     def __init__(self, start=None, size=None, **extra):
-        super(_FilterNoInput, self).__init__(**extra)
+        super().__init__(**extra)
         if start is not None:
             self['x'] = start[0]
             self['y'] = start[1]
@@ -69,7 +68,7 @@ class _FilterNoInput(_FilterPrimitive):
 
 class _FilterRequireInput(_FilterNoInput):
     def __init__(self, in_='SourceGraphic', **extra):
-        super(_FilterRequireInput, self).__init__(**extra)
+        super().__init__(**extra)
         self['in'] = in_
 
 
@@ -101,7 +100,7 @@ class _feFuncR(_FilterPrimitive):
     elementname = 'feFuncR'
 
     def __init__(self, type_, **extra):
-        super(_feFuncR, self).__init__(**extra)
+        super().__init__(**extra)
         self['type'] = type_
 
 
@@ -154,7 +153,7 @@ class _feImage(_FilterNoInput, XLink):
     elementname = 'feImage'
 
     def __init__(self, href, start=None, size=None, **extra):
-        super(_feImage, self).__init__(start, size, **extra)
+        super().__init__(start, size, **extra)
         self.set_href(href)
 
 
@@ -165,7 +164,7 @@ class _feMergeNode(_FilterPrimitive):
 class _feMerge(_FilterNoInput):
     elementname = 'feMerge'
     def __init__(self, layernames, **extra):
-        super(_feMerge, self).__init__(**extra)
+        super().__init__(**extra)
         self.feMergeNode(layernames)
 
     def feMergeNode(self, layernames):
@@ -213,7 +212,7 @@ filter_factory = {
 }
 
 
-class _FilterBuilder(object):
+class _FilterBuilder:
     def __init__(self, cls, parent):
         self.cls = cls # primitive filter class to build
         self.parent = parent # the parent Filter() object
@@ -241,7 +240,7 @@ class Filter(BaseElement, XLink, Presentation):
         :param inherit: inherits properties from Filter `inherit` see: **xlink:href**
 
         """
-        super(Filter, self).__init__(**extra)
+        super().__init__(**extra)
         if start is not None:
             self['x'] = start[0]
             self['y'] = start[1]
@@ -262,7 +261,7 @@ class Filter(BaseElement, XLink, Presentation):
 
     def get_xml(self):
         self.update_id()
-        return super(Filter, self).get_xml()
+        return super().get_xml()
 
     def __getattr__(self, name):
         # create primitive filters by Filter.<filtername>(...)
@@ -270,4 +269,4 @@ class Filter(BaseElement, XLink, Presentation):
         if name in filter_factory:
             return _FilterBuilder(filter_factory[name], self)
         else:
-            raise AttributeError("'%s' has no attribute '%s'" % (self.__class__.__name__, name))
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")

--- a/svgwrite/gradients.py
+++ b/svgwrite/gradients.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: gradients module
 # Created: 26.10.2010
@@ -21,7 +20,7 @@ class _GradientStop(BaseElement):
     elementname = 'stop'
 
     def __init__(self, offset=None, color=None, opacity=None, **extra):
-        super(_GradientStop, self).__init__(**extra)
+        super().__init__(**extra)
 
         if offset is not None:
             self['offset'] = offset
@@ -35,7 +34,7 @@ class _AbstractGradient(BaseElement, Transform, XLink):
     transformname = 'gradientTransform'
 
     def __init__(self, inherit=None, **extra):
-        super(_AbstractGradient, self).__init__(**extra)
+        super().__init__(**extra)
         if inherit is not None:
             if is_string(inherit):
                 self.set_href(inherit)
@@ -44,7 +43,7 @@ class _AbstractGradient(BaseElement, Transform, XLink):
 
     def get_paint_server(self, default='none'):
         """ Returns the <FuncIRI> of the gradient. """
-        return "%s %s" % (self.get_funciri(), default)
+        return f"{self.get_funciri()} {default}"
 
     def add_stop_color(self, offset=None, color=None, opacity=None):
         """ Adds a stop-color to the gradient.
@@ -79,7 +78,7 @@ class _AbstractGradient(BaseElement, Transform, XLink):
     def get_xml(self):
         if hasattr(self, 'href'):
             self.update_id()
-        return super(_AbstractGradient, self).get_xml()
+        return super().get_xml()
 
 
 class LinearGradient(_AbstractGradient):
@@ -94,7 +93,7 @@ class LinearGradient(_AbstractGradient):
         :param inherit: gradient inherits properties from `inherit` see: **xlink:href**
 
         """
-        super(LinearGradient, self).__init__(inherit=inherit, **extra)
+        super().__init__(inherit=inherit, **extra)
         if start is not None:
             self['x1'] = start[0]
             self['y1'] = start[1]
@@ -117,7 +116,7 @@ class RadialGradient(_AbstractGradient):
 
         """
 
-        super(RadialGradient, self).__init__(inherit=inherit, **extra)
+        super().__init__(inherit=inherit, **extra)
         if center is not None:
             self['cx'] = center[0]
             self['cy'] = center[1]

--- a/svgwrite/image.py
+++ b/svgwrite/image.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: svg image element
 # Created: 09.10.2010
@@ -26,7 +25,7 @@ class Image(BaseElement, Transform, Clipping):
         :param dict attribs: additional SVG attributes
         :param extra: additional SVG attributes as keyword-arguments
         """
-        super(Image, self).__init__(**extra)
+        super().__init__(**extra)
         self['xlink:href'] = href
         if insert is not None:
             self['x'] = insert[0]
@@ -58,4 +57,4 @@ class Image(BaseElement, Transform, Clipping):
         """
         if self.debug and scale not in ('meet', 'slice'):
             raise ValueError("Invalid scale parameter '%s'" % scale)
-        self.attribs['preserveAspectRatio'] = "%s%s %s" % (_horiz[horiz],_vert[vert], scale)
+        self.attribs['preserveAspectRatio'] = "{}{} {}".format(_horiz[horiz],_vert[vert], scale)

--- a/svgwrite/masking.py
+++ b/svgwrite/masking.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: masking module
 # Created: 30.10.2010
@@ -41,7 +40,7 @@ class Mask(BaseElement):
     elementname = 'mask'
 
     def __init__(self, start=None, size=None, **extra):
-        super(Mask, self).__init__(**extra)
+        super().__init__(**extra)
         if start is not None:
             self['x'] = start[0]
             self['y'] = start[1]

--- a/svgwrite/mixins.py
+++ b/svgwrite/mixins.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: mixins
 # Created: 19.10.2010
@@ -12,7 +11,7 @@ from svgwrite.utils import is_string
 _horiz = {'center': 'xMid', 'left': 'xMin', 'right': 'xMax'}
 _vert  = {'middle': 'YMid', 'top': 'YMin', 'bottom':'YMax'}
 
-class ViewBox(object):
+class ViewBox:
     """ The **ViewBox** mixin provides the ability to specify that a
     given set of graphics stretch to fit a particular container element.
 
@@ -61,9 +60,9 @@ class ViewBox(object):
         """
         if self.debug and scale not in ('meet', 'slice'):
             raise ValueError("Invalid scale parameter '%s'" % scale)
-        self['preserveAspectRatio'] = "%s%s %s" % (_horiz[horiz],_vert[vert], scale)
+        self['preserveAspectRatio'] = "{}{} {}".format(_horiz[horiz],_vert[vert], scale)
 
-class Transform(object):
+class Transform:
     """ The **Transform** mixin operates on the **transform** attribute.
     The value of the **transform** attribute is a `<transform-list>`, which
     is defined as a list of transform definitions, which are applied in the
@@ -127,10 +126,10 @@ class Transform(object):
 
     def _add_transformation(self, new_transform):
         old_transform = self.attribs.get(self.transformname, '')
-        self[self.transformname] = ("%s %s" % (old_transform, new_transform)).strip()
+        self[self.transformname] = (f"{old_transform} {new_transform}").strip()
 
 
-class XLink(object):
+class XLink:
     """ XLink mixin """
     def set_href(self, element):
         """
@@ -166,7 +165,7 @@ class XLink(object):
         self.attribs['xlink:href'] = idstr
 
 
-class Presentation(object):
+class Presentation:
     """
     Helper methods to set presentation attributes.
     """
@@ -227,7 +226,7 @@ class Presentation(object):
         return self
 
 
-class MediaGroup(object):
+class MediaGroup:
     """
     Helper methods to set media group attributes.
 
@@ -245,7 +244,7 @@ class MediaGroup(object):
         return self
 
 
-class Markers(object):
+class Markers:
     """
     Helper methods to set marker attributes.
 
@@ -289,10 +288,10 @@ class Markers(object):
                 self['marker'] = get_funciri(markers)
 
 
-class Clipping(object):
+class Clipping:
     def clip_rect(self, top='auto', right='auto', bottom='auto', left='auto'):
         """
         Set SVG Property **clip**.
 
         """
-        self['clip'] = "rect(%s,%s,%s,%s)" % (top, right, bottom, left)
+        self['clip'] = f"rect({top},{right},{bottom},{left})"

--- a/svgwrite/params.py
+++ b/svgwrite/params.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman
 # Purpose: svgwrite package parameter
 # Created: 10.09.2010
@@ -9,7 +8,7 @@
 from svgwrite.validator2 import get_validator
 
 
-class Parameter(object):
+class Parameter:
     """
     .. attribute:: Parameter.debug
 

--- a/svgwrite/path.py
+++ b/svgwrite/path.py
@@ -1,4 +1,3 @@
-#coding:utf-8
 # Author:  mozman
 # Purpose: svg path element
 # Created: 08.09.2010
@@ -23,7 +22,7 @@ class Path(BaseElement, Transform, Presentation, Markers):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Path, self).__init__(**extra)
+        super().__init__(**extra)
         self.commands = []
         self.push(d)
         if self.debug:
@@ -72,4 +71,4 @@ class Path(BaseElement, Transform, Presentation, Markers):
 
         """
         self.attribs['d'] = str(strlist(self.commands, ' '))
-        return super(Path, self).get_xml()
+        return super().get_xml()

--- a/svgwrite/pattern.py
+++ b/svgwrite/pattern.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: pattern module
 # Created: 29.10.2010
@@ -29,7 +28,7 @@ class Pattern(BaseElement, XLink, ViewBox, Transform, Presentation):
         :param inherit: pattern inherits properties from `inherit` see: **xlink:href**
 
         """
-        super(Pattern, self).__init__(**extra)
+        super().__init__(**extra)
         if insert is not None:
             self['x'] = insert[0]
             self['y'] = insert[1]
@@ -47,4 +46,4 @@ class Pattern(BaseElement, XLink, ViewBox, Transform, Presentation):
 
     def get_paint_server(self, default='none'):
         """ Returns the <FuncIRI> of the gradient. """
-        return "%s %s" % (self.get_funciri(), default)
+        return f"{self.get_funciri()} {default}"

--- a/svgwrite/shapes.py
+++ b/svgwrite/shapes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman <me@mozman.at>
 # Purpose: svg shapes
 # Created: 08.09.2010
@@ -23,7 +22,7 @@ class Line(BaseElement, Transform, Presentation, Markers):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Line, self).__init__(**extra)
+        super().__init__(**extra)
         x1, y1 = start
         x2, y2 = end
         self['x1'] = x1
@@ -48,7 +47,7 @@ class Rect(BaseElement, Transform, Presentation):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Rect, self).__init__(**extra)
+        super().__init__(**extra)
         x, y = insert
         width, height = size
         self['x'] = x
@@ -73,7 +72,7 @@ class Circle(BaseElement, Transform, Presentation):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Circle, self).__init__(**extra)
+        super().__init__(**extra)
         cx, cy = center
         self['cx'] = cx
         self['cy'] = cy
@@ -93,7 +92,7 @@ class Ellipse(BaseElement, Transform, Presentation):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Ellipse, self).__init__(**extra)
+        super().__init__(**extra)
         cx, cy = center
         rx, ry = r
         self['cx'] = cx
@@ -114,7 +113,7 @@ class Polyline(BaseElement, Transform, Presentation, Markers):
         :param extra: additional SVG attributes as keyword-arguments
 
         """
-        super(Polyline, self).__init__(**extra)
+        super().__init__(**extra)
         self.points = list(points)
         if self.debug:
             for point in self.points:
@@ -124,7 +123,7 @@ class Polyline(BaseElement, Transform, Presentation, Markers):
 
     def get_xml(self):
         self.attribs['points'] = self.points_to_string(self.points)
-        return super(Polyline, self).get_xml()
+        return super().get_xml()
 
     def points_to_string(self, points):
         """
@@ -144,7 +143,7 @@ class Polyline(BaseElement, Transform, Presentation, Markers):
                     x = round(x, 4)
                 if isinstance(y, float):
                     y = round(y, 4)
-            point = "%s,%s" % (x, y)
+            point = f"{x},{y}"
             strings.append(point)
         return ' '.join(strings)
 

--- a/svgwrite/solidcolor.py
+++ b/svgwrite/solidcolor.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: solidColor paint serve (Tiny 1.2 profile)
 # Created: 26.10.2016
@@ -26,7 +25,7 @@ class SolidColor(BaseElement, XLink):
         :param float opacity: opacity of the solid color in the range `0.0` (fully transparent) to `1.0` (fully opaque)
 
         """
-        super(SolidColor, self).__init__(**extra)
+        super().__init__(**extra)
         if self.profile != 'tiny':
             raise TypeError("Paint server 'solidColor' requires the Tiny SVG profile.")
         self['solid-color'] = color
@@ -38,4 +37,4 @@ class SolidColor(BaseElement, XLink):
 
     def get_paint_server(self, default='none'):
         """ Returns the <FuncIRI> of the gradient. """
-        return "%s %s" % (self.get_funciri(), default)
+        return f"{self.get_funciri()} {default}"

--- a/svgwrite/text.py
+++ b/svgwrite/text.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: text objects
 # Created: 20.09.2010
@@ -42,7 +41,7 @@ class TSpan(BaseElement, Presentation):
         :param list rotate: list of rotation-values for characters (in degrees)
 
         """
-        super(TSpan, self).__init__(**extra)
+        super().__init__(**extra)
         self.text = text
         if insert is not None:
             if is_string(insert):
@@ -66,7 +65,7 @@ class TSpan(BaseElement, Presentation):
             self['rotate'] = strlist(list(iterflatlist(rotate)), ' ')
 
     def get_xml(self):
-        xml = super(TSpan, self).get_xml()
+        xml = super().get_xml()
         xml.text = str(self.text)
         return xml
 
@@ -99,12 +98,12 @@ class TRef(BaseElement, XLink, Presentation):
                         the **id** SVG Attribute is used to create the reference.
 
         """
-        super(TRef, self).__init__(**extra)
+        super().__init__(**extra)
         self.set_href(element)
 
     def get_xml(self):
         self.update_id()  # if href is an object - 'id' - attribute may be changed!
-        return super(TRef, self).get_xml()
+        return super().get_xml()
 
 
 class TextPath(BaseElement, XLink, Presentation):
@@ -128,7 +127,7 @@ class TextPath(BaseElement, XLink, Presentation):
         :param string spacing: ``exact|auto``
 
         """
-        super(TextPath, self).__init__(**extra)
+        super().__init__(**extra)
         self.text = text
         if method == 'stretch':
             self['method'] = method
@@ -140,7 +139,7 @@ class TextPath(BaseElement, XLink, Presentation):
 
     def get_xml(self):
         self.update_id() # if href is an object - 'id' - attribute may be changed!
-        xml = super(TextPath, self).get_xml()
+        xml = super().get_xml()
         xml.text = str(self.text)
         return xml
 
@@ -149,7 +148,7 @@ class TBreak(BaseElement):
     elementname = 'tbreak'
 
     def __init__(self, **extra):
-        super(TBreak, self).__init__(**extra)
+        super().__init__(**extra)
 
     def __getitem__(self, key):
         raise NotImplementedError("__getitem__() not supported by TBreak class.")
@@ -184,7 +183,7 @@ class TextArea(BaseElement, Transform, Presentation):
     elementname = 'textArea'
 
     def __init__(self, text=None, insert=None, size=None, **extra):
-        super(TextArea, self).__init__(**extra)
+        super().__init__(**extra)
         if text is not None:
             self.write(text)
         if insert is not None:

--- a/svgwrite/utils.py
+++ b/svgwrite/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  mozman
 # Purpose: svg util functions and classes
 # Created: 08.09.2010
@@ -78,8 +77,7 @@ def iterflatlist(values):
     """
     for element in values:
         if hasattr(element, "__iter__") and not is_string(element):
-            for item in iterflatlist(element):
-                yield item
+            yield from iterflatlist(element)
         else:
             yield element
 
@@ -193,13 +191,13 @@ def rect_top_left_corner(insert, size, pos='top-left'):
         raise ValueError("Invalid vertical position: '%s'" % vert)
 
     if xunit:
-        x = "%s%s" % (x, xunit)
+        x = f"{x}{xunit}"
     if yunit:
-        y = "%s%s" % (y, yunit)
+        y = f"{y}{yunit}"
     return x, y
 
 
-class AutoID(object):
+class AutoID:
     _nextid = 1
 
     def __init__(self, value=None):
@@ -254,7 +252,7 @@ def font_mimetype(name):
 
 def base64_data(data, mimetype):
     data = base64.b64encode(data).decode()
-    return "data:{mimetype};charset=utf-8;base64,{data}".format(mimetype=mimetype, data=data)
+    return f"data:{mimetype};charset=utf-8;base64,{data}"
 
 
 def find_first_url(text):

--- a/svgwrite/validator2.py
+++ b/svgwrite/validator2.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: validator2 module - new validator module
 # Created: 01.10.2010
@@ -32,7 +31,7 @@ def get_validator(profile, debug=True):
         return validator
 
 
-class Tiny12Validator(object):
+class Tiny12Validator:
     profilename = "Tiny 1.2"
 
     def __init__(self, debug=True):
@@ -76,7 +75,7 @@ class Tiny12Validator(object):
         # check if 'value' is a valid constant
         valuestr = str(value)
         if not valuestr in attribute.get_const(elementname):
-            raise TypeError("'%s' is not a valid value for attribute '%s' at svg-element <%s>." % (value, attributename, elementname))
+            raise TypeError(f"'{value}' is not a valid value for attribute '{attributename}' at svg-element <{elementname}>.")
 
     def _check_valid_svg_attribute_name(self, elementname, attributename):
         """ Check if 'attributename' is a valid svg-attribute for svg-element
@@ -85,13 +84,13 @@ class Tiny12Validator(object):
         Raises ValueError.
         """
         if not self.is_valid_svg_attribute(elementname, attributename):
-            raise ValueError("Invalid attribute '%s' for svg-element <%s>." % (attributename, elementname))
+            raise ValueError(f"Invalid attribute '{attributename}' for svg-element <{elementname}>.")
 
     def _get_element(self, elementname):
         try:
             return self.elements[elementname]
         except KeyError:
-            raise KeyError("<%s> is not valid for selected profile: '%s'." % (elementname, self.profilename))
+            raise KeyError(f"<{elementname}> is not valid for selected profile: '{self.profilename}'.")
 
     def check_svg_type(self, value, typename='string'):
         """
@@ -102,7 +101,7 @@ class Tiny12Validator(object):
         if self.typechecker.check(typename, value):
             return value
         else:
-            raise TypeError("%s is not of type '%s'." % (value, typename))
+            raise TypeError(f"{value} is not of type '{typename}'.")
 
     def is_valid_svg_type(self, value, typename):
         return self.typechecker.check(typename, value)
@@ -132,7 +131,7 @@ class Tiny12Validator(object):
         Raises ValueError.
         """
         if not self.is_valid_children(elementname, childrenname):
-            raise ValueError("Invalid children '%s' for svg-element <%s>." % (childrenname, elementname))
+            raise ValueError(f"Invalid children '{childrenname}' for svg-element <{elementname}>.")
 
     def get_coordinate(self, value):
         """ Split value in (number, unit) if value has an unit or (number, None).
@@ -156,7 +155,7 @@ class Tiny12Validator(object):
             return result
         else:
             version = "SVG %s %s" % self.typechecker.get_version()
-            raise ValueError("%s is not a valid number for: %s." % (value, version))
+            raise ValueError(f"{value} is not a valid number for: {version}.")
     get_length = get_coordinate
 
 

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test animate
 # Created: 31.10.2010

--- a/tests/test_animation_timing_parser.py
+++ b/tests/test_animation_timing_parser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test animation_timing_parser
 # Created: 03.11.2010

--- a/tests/test_base_element.py
+++ b/tests/test_base_element.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test BaseElement
 # Created: 18.09.2010
@@ -66,9 +65,9 @@ class TestBaseElement(unittest.TestCase):
 class TestValueToString(unittest.TestCase):
     def test_full_profile(self):
         element = MockBase()
-        self.assertEqual(u'test', element.value_to_string('test'))
-        self.assertEqual(u'süß', element.value_to_string('süß'))
-        self.assertEqual(u'10', element.value_to_string(10))
+        self.assertEqual('test', element.value_to_string('test'))
+        self.assertEqual('süß', element.value_to_string('süß'))
+        self.assertEqual('10', element.value_to_string(10))
 
     def test_tiny_profile(self):
         element = MockBase()

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test circle object
 # Created: 25.09.2010

--- a/tests/test_clippath.py
+++ b/tests/test_clippath.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test ClipPath
 # Created: 31.10.2010

--- a/tests/test_clipping.py
+++ b/tests/test_clipping.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test mixin Clipping
 # Created: 31.10.2010

--- a/tests/test_clock_val_parser.py
+++ b/tests/test_clock_val_parser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test clock_val_parser
 # Created: 03.11.2010

--- a/tests/test_defs.py
+++ b/tests/test_defs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test defs element
 # Created: 25.09.2010

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test Description mixin
 # Created: 04.11.2010

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test drawing module
 # Created: 11.09.2010

--- a/tests/test_elementfactory.py
+++ b/tests/test_elementfactory.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test elementfactory
 # Created: 15.10.2010

--- a/tests/test_ellipse.py
+++ b/tests/test_ellipse.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test ellipse object
 # Created: 25.09.2010

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test filters module
 # Created: 04.11.2010

--- a/tests/test_full11_typechecker.py
+++ b/tests/test_full11_typechecker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test full11typechecker
 # Created: 04.10.2010
@@ -31,7 +30,7 @@ class TestFull11TypeChecker(unittest.TestCase):
         self.assertTrue(self.checker.is_anything(100))
         self.assertTrue(self.checker.is_anything((100, 11)))
         self.assertTrue(self.checker.is_anything(dict(a=100, b=200)))
-        self.assertTrue(self.checker.is_anything(u'äüß'.encode('utf-8')))
+        self.assertTrue(self.checker.is_anything('äüß'.encode()))
 
     def test_is_number(self):
         """ Integer and Float, also as String '100' or '3.1415'. """

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test gradients module
 # Created: 26.10.2010

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test group element
 # Created: 25.09.2010

--- a/tests/test_hyperlink.py
+++ b/tests/test_hyperlink.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test hyperlink object
 # Created: 09.10.2010

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test image object
 # Created: 09.10.2010

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test line object
 # Created: 25.09.2010

--- a/tests/test_marker_class.py
+++ b/tests/test_marker_class.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test marker element
 # Created: 24.10.2010

--- a/tests/test_markers_mixin.py
+++ b/tests/test_markers_mixin.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test markers mixin
 # Created: 24.10.2010

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test Mask
 # Created: 31.10.2010

--- a/tests/test_mediagroup.py
+++ b/tests/test_mediagroup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test MediaGroup mixin
 # Created: 24.10.2010

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test parameter module
 # Created: 10.09.2010

--- a/tests/test_parsing_basic_types.py
+++ b/tests/test_parsing_basic_types.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test parsing basic types
 # Created: 17.10.2010

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test path class
 # Created: 18.09.2010

--- a/tests/test_pathdataparser.py
+++ b/tests/test_pathdataparser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: transform list parser
 # Created: 10.10.2010

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test pattern module
 # Created: 29.10.2010

--- a/tests/test_polyline.py
+++ b/tests/test_polyline.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test polyline object
 # Created: 25.09.2010

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test presentation mixin
 # Created: 24.10.2010

--- a/tests/test_pretty_xml.py
+++ b/tests/test_pretty_xml.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman <me@mozman.at>
 # Purpose: test pretty_xml function
 # Created: 28.01.2017

--- a/tests/test_rect.py
+++ b/tests/test_rect.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test rect object
 # Created: 25.09.2010

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test script element
 # Created: 25.09.2010

--- a/tests/test_solid_color.py
+++ b/tests/test_solid_color.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test solidcolor module
 # Created: 26.10.2016

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test style element
 # Created: 27.05.2012

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test svg element
 # Created: 25.09.2010

--- a/tests/test_svgattributes.py
+++ b/tests/test_svgattributes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test SVGAttribute
 # Created: 12.10.2010

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test symbol element
 # Created: 25.09.2010

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test text module
 # Created: 25.09.2010

--- a/tests/test_textarea.py
+++ b/tests/test_textarea.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test TextArea class
 # Created: 14.10.2010

--- a/tests/test_tiny12_typechecker.py
+++ b/tests/test_tiny12_typechecker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test tiny12 typechecker
 # Created: 08.10.2010

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test ITransform interface
 # Created: 25.09.2010

--- a/tests/test_transformlistparser.py
+++ b/tests/test_transformlistparser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: transform list parser
 # Created: 10.10.2010

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test svg element
 # Created: 25.09.2010

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  mozman <me@mozman.at>
 # Purpose: test utils module
 # Created: 10.09.2010

--- a/tests/test_validator2.py
+++ b/tests/test_validator2.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test utils module
 # Created: 10.09.2010

--- a/tests/test_viewbox.py
+++ b/tests/test_viewbox.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test ITransform interface
 # Created: 25.09.2010

--- a/tests/test_xlink.py
+++ b/tests/test_xlink.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding:utf-8
 # Author:  mozman --<mozman@gmx.at>
 # Purpose: test ITransform interface
 # Created: 25.09.2010


### PR DESCRIPTION
Modernize code to Python 3.6+ using `pyupgrade --py36-plus`, which changes automatically:

1. removes the encoding info from files (utf-8 is standard)
2. Python3 class syntax (default inheritance from `object` needed)
3. apply f-strings where it looks good
4. default arguments for `super()`
5. remove redundant parentheses
