### PR TITLE
Note library is dependency free

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ for more examples see: examples.py
 As the name `svgwrite` implies, `svgwrite` creates new SVG drawings, it does not read existing drawings and also does
 not import existing drawings, but you can always include other SVG drawings by the <image> entity.
 
+`svgwrite` is Pure python and has no external dependencies.
+
 Installation
 ------------
 


### PR DESCRIPTION
Was evaluating svg libraries and found this. That the library is pure Python and has no external dependencies is a huge positive which I thought should be highlighted on the front-page. At least, it was enough to sway me vs alternatives.